### PR TITLE
Merging forward calandar function into main

### DIFF
--- a/components/instructor-calandar-view/instCal-day.js
+++ b/components/instructor-calandar-view/instCal-day.js
@@ -2,6 +2,12 @@ import instructorCal from '../../styles/instructorCal.module.scss';
 
 const timeSlotsArr = ["1:00", "2:00", "3:00", "4:00", "5:00"]
 
+const d = new Date();
+const today =  (d.getMonth() + " " + d.getDay() + " " + d.getDate())
+const date = d.getDate()
+const day = d.getDay()
+
+
 export default function InstCalandarDay({handleLessonDet}) {
     
 

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -4,7 +4,8 @@ import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { todayDate } from '../../redux/calandarDataSlice'
+import { nextWeek } from '../../redux/calandarDataSlice'
+
 
 const weekDaysArr = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 
@@ -12,18 +13,18 @@ const InstCalandarView = () => {
 
     const [showLessonDet, setShowLessonDet] = useState(false);
 
-    useEffect(() => {
-        console.log("Show Lesson Det is now:", showLessonDet);
-    }, [showLessonDet]);
+    // useEffect(() => {
+    //     console.log("Show Lesson Det is now:", showLessonDet);
+    // }, [showLessonDet]);
 
     const handleLessonDet = (e) => {
             e.preventDefault();
-            setShowLessonDet( (showLessonDet) =>{
+            setShowLessonDet((showLessonDet) =>{
               
-                if(!showLessonDet) {
-                    setShowLessonDet(true)
-                } else {
+                if(showLessonDet) {
                     setShowLessonDet(false)
+                } else {
+                    setShowLessonDet(true)
                 }
             });
     }
@@ -38,8 +39,13 @@ const InstCalandarView = () => {
         </div>
         )
 
-        const today = useSelector((state) => state.calandarData.today)
+        const today = useSelector((state) => state.calandarData.date)
+        const year = useSelector((state) => state.calandarData.year)
+        const month = useSelector((state) => state.calandarData.month)
         const dispatch = useDispatch()
+       
+        const startingDate = new Date(year, month, 1)
+        console.log("starting Date", startingDate)
 
     return (
         <div className={instructorCal.calContainer}>
@@ -49,7 +55,7 @@ const InstCalandarView = () => {
                     {today}
                 </label>
                 <button 
-                    onClick={() =>dispatch(todayDate())}
+                    onClick={() =>dispatch(nextWeek())}
                 >
                     aro
                 </button>

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -4,12 +4,12 @@ import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear, reverseYear } from '../../redux/weekNavSlice'
+import { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear } from '../../redux/weekNavSlice'
 
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const monthArr =['Jan', 'Feb', 'March', 'April', 'May', 'June', 'July', 'August', 'Sept', 'Oct', 'Nov', 'Dec']
-let directionCheck = 1
+let dispatchCheck = 0
 const InstCalandarView = () => {
 
     const [showLessonDet, setShowLessonDet] = useState(false);
@@ -28,6 +28,7 @@ const InstCalandarView = () => {
 
     const baseDay = useSelector(state => state.weekNav.baseDay)
     const month = useSelector(state => state.weekNav.month)
+    const advanceMonth = useSelector(state => state.weekNav.advanceMonth)
     const year = useSelector(state => state.weekNav.year)
     const dispatch = useDispatch()
     
@@ -39,55 +40,32 @@ const InstCalandarView = () => {
         const getDaysInMonth = (year, month) => {
             return new Date(year, month, 0).getDate();
         }
+        // const currentYear = d.getFullYear()
         const daysInMonth = (m) => {
             return getDaysInMonth(year, m + 1, 0)
         }
         
         const dayOfWeek = () => {
             const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-            const reverseDateAdjust = ((weekDaysArr.indexOf(day) + dayNum) - baseDay)
-          //  console.log("days in", monthArr[month], daysInMonth(month))
+
             if (weekDaysArr.indexOf(day) === dayNum) {  // For today
                 const today = baseDay 
                 console.log("today", today)
-                console.log("Today Direction Check", directionCheck)
-                if (today > daysInMonth(month)) {
-                    today -= daysInMonth(month)
-                    return today;
-                }
                 return today
 
-            } else if (weekDaysArr.indexOf(day) > dayNum && directionCheck >= 0) {  //For all days ahead of today
+            } else if (weekDaysArr.indexOf(day) > dayNum) {  //For all days ahead of today
                 const daysAhead = dateAdjust
                 console.log("daysAhead", daysAhead)
-                console.log("DaysAhead Direction Check", directionCheck)
                 if (daysAhead > daysInMonth(month)) { //At the end of the month when the days ahead of today are in the next month
                     daysAhead = daysAhead - daysInMonth(month) //the month is accurate
                     return daysAhead
                 }
+                
+
                 return daysAhead
-            } else if (weekDaysArr.indexOf(day) < dayNum && directionCheck >= 0) { //For all days behind today
+            } else if (weekDaysArr.indexOf(day) < dayNum) { //For all days behind today
                 const daysBehind = dateAdjust
-                console.log("DasyBehind Direction Check", directionCheck)
-              //  console.log("daysBehind", daysBehind)
-                if (daysBehind <= 0) { //At the beginning of the month when the days behind today are in the last month 
-                    daysBehind += daysInMonth(month-1) //the month is accurate so last month is -1
-                    return daysBehind
-                }
-                return daysBehind
-            } else if (weekDaysArr.indexOf(day) < dayNum && directionCheck <= 0) {  //For all days ahead of today
-                const daysAhead = reverseDateAdjust
-                console.log("REVERSE daysAhead", daysAhead)
-                console.log(" REVERSE DaysAhead Direction Check", directionCheck)
-                if (daysAhead > daysInMonth(month)) { //At the end of the month when the days ahead of today are in the next month
-                    daysAhead = daysAhead - daysInMonth(month) //the month is accurate
-                    return daysAhead
-                }
-                return daysAhead
-            } else if (weekDaysArr.indexOf(day) > dayNum && directionCheck <= 0) { //For all days behind today
-                const daysBehind = dateAdjust -daysInMonth(month)
-                console.log("REVERSE DasyBehind Direction Check", directionCheck)
-              //  console.log("daysBehind", daysBehind)
+                console.log("daysBehind", daysBehind)
                 if (daysBehind <= 0) { //At the beginning of the month when the days behind today are in the last month 
                     daysBehind += daysInMonth(month-1) //the month is accurate so last month is -1
                     return daysBehind
@@ -95,22 +73,15 @@ const InstCalandarView = () => {
                 return daysBehind
             }
             
+            
         }
        console.log(dayOfWeek())
         useEffect(() => {
-            if(dayOfWeek() > daysInMonth(month) && directionCheck >= 0){ //month is accurate
+            if(dayOfWeek() > daysInMonth(month) && dispatchCheck > 0){ //month is accurate
                 dispatch(advanceMonthAdvance(1));
                 dispatch(advanceYear(1));
-                directionCheck=0;
-                console.log("USE EFFECT DIRECTION CHECK", directionCheck)
-            } else if (dayOfWeek() <= 1 && directionCheck < 0) {
-                dispatch(reverseMonthAdvance(1));
-                dispatch(reverseYear(1));
-                //directionCheck=0;
-                console.log("USE EFFECT DIRECTION CHECK", directionCheck)
-            }
-            console.log("Month in USE EFFECT", monthArr[month])
-        
+                dispatchCheck=0;
+            } 
         }, [baseDay]);
 
         return (
@@ -130,10 +101,9 @@ const InstCalandarView = () => {
             <div className={instructorCal.dateSlide}>
                 <button
                     onClick={() =>{
-                        directionCheck = -1;
                         dispatch(lastWeek(7))
-                        console.log("BACK directionCheck", directionCheck)
-                        return directionCheck;
+                        dispatchCheck = -1;
+                        return dispatchCheck;
                         }
                     }
                 >
@@ -144,10 +114,9 @@ const InstCalandarView = () => {
                 </label>
                 <button 
                     onClick={() =>{
-                        directionCheck = 1;
                         dispatch(nextWeek(7))
-                        console.log("FORWARD directionCheck", directionCheck)
-                        return directionCheck;
+                        dispatchCheck = 1;
+                        return dispatchCheck;
                         } 
                     }
                 >
@@ -164,7 +133,6 @@ const InstCalandarView = () => {
             </div>
         </div>
         )
-      
     }
 
 export default InstCalandarView

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -4,7 +4,7 @@ import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear } from '../../redux/weekNavSlice'
+import { nextWeek, lastWeek, advanceMonth, advanceYear } from '../../redux/weekNavSlice'
 
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -28,7 +28,6 @@ const InstCalandarView = () => {
 
     const baseDay = useSelector(state => state.weekNav.baseDay)
     const month = useSelector(state => state.weekNav.month)
-    const advanceMonth = useSelector(state => state.weekNav.advanceMonth)
     const year = useSelector(state => state.weekNav.year)
     const dispatch = useDispatch()
     
@@ -40,7 +39,7 @@ const InstCalandarView = () => {
         const getDaysInMonth = (year, month) => {
             return new Date(year, month, 0).getDate();
         }
-        // const currentYear = d.getFullYear()
+
         const daysInMonth = (m) => {
             return getDaysInMonth(year, m + 1, 0)
         }
@@ -78,7 +77,7 @@ const InstCalandarView = () => {
        console.log(dayOfWeek())
         useEffect(() => {
             if(dayOfWeek() > daysInMonth(month) && dispatchCheck > 0){ //month is accurate
-                dispatch(advanceMonthAdvance(1));
+                dispatch(advanceMonth(1));
                 dispatch(advanceYear(1));
                 dispatchCheck=0;
             } 

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -3,6 +3,8 @@ import instructorCal from '../../styles/instructorCal.module.scss';
 import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
+import { useSelector, useDispatch } from 'react-redux';
+import { todayDate } from '../../redux/calandarDataSlice'
 
 const weekDaysArr = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 
@@ -25,34 +27,41 @@ const InstCalandarView = () => {
                 }
             });
     }
-  
-        const weekDays = weekDaysArr.map((day) =>
-            <div 
-                className={instructorCal.dayContainer} 
-                key={day.toString()}
-            >
-                {day}
-                <InstCalandarDay handleLessonDet={handleLessonDet}/>
-            </div>
-            )
+    
+    const weekDays = weekDaysArr.map((day) =>
+        <div 
+            className={instructorCal.dayContainer} 
+            key={day.toString()}
+        >
+            {day}
+            <InstCalandarDay handleLessonDet={handleLessonDet}/>
+        </div>
+        )
 
-        return (
-            <div className={instructorCal.calContainer}>
-                <div className={instructorCal.dateSlide}>
-                    <button>aro</button>
-                    <label className={instructorCal.slideText}>
-                        Week of August 7th
-                    </label>
-                    <button>aro</button>
-                </div>
-                <div className={instructorCal.weekContainer}>
-                    {weekDays}
-                </div>
-                <div className={instructorCal.controlContainer}>
-                <LessonCalControl className={instructorCal.lessonControl}/>
-                <InstructorLessonDetail showLessonDet={showLessonDet}/>
-                </div>
+        const today = useSelector((state) => state.calandarData.today)
+        const dispatch = useDispatch()
+
+    return (
+        <div className={instructorCal.calContainer}>
+            <div className={instructorCal.dateSlide}>
+                <button>aro</button>
+                <label className={instructorCal.slideText}>
+                    {today}
+                </label>
+                <button 
+                    onClick={() =>dispatch(todayDate())}
+                >
+                    aro
+                </button>
             </div>
+            <div className={instructorCal.weekContainer}>
+                {weekDays}
+            </div>
+            <div className={instructorCal.controlContainer}>
+            <LessonCalControl className={instructorCal.lessonControl}/>
+            <InstructorLessonDetail showLessonDet={showLessonDet}/>
+            </div>
+        </div>
         )
     }
 

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -5,10 +5,10 @@ import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesso
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
 import { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear } from '../../redux/weekNavSlice'
-import { end, start } from '@popperjs/core';
 
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const monthArr =['Jan', 'Feb', 'March', 'April', 'May', 'June', 'July', 'August', 'Sept', 'Oct', 'Nov', 'Dec']
 let dispatchCheck = 0
 const InstCalandarView = () => {
 
@@ -31,8 +31,8 @@ const InstCalandarView = () => {
     const advanceMonth = useSelector(state => state.weekNav.advanceMonth)
     const year = useSelector(state => state.weekNav.year)
     const dispatch = useDispatch()
-   
-
+    
+        
     const weekDays = weekDaysArr.map(function(day) {
    
         const d = new Date();
@@ -48,6 +48,7 @@ const InstCalandarView = () => {
             
             if (weekDaysArr.indexOf(day) === dayNum) {
                     //console.log("baseday", baseDay)
+                    
                     if(baseDay===0) {
                         const lastDay = daysInMonth(d.getMonth() + advanceMonth - 1)
                         return lastDay
@@ -57,11 +58,11 @@ const InstCalandarView = () => {
                 return baseDay
                 } else {
                     const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-                    console.log("dateAdjust", dateAdjust)
-                    console.log(dispatchCheck)
-                    console.log("baseday", baseDay)
-                    console.log("index of this day", weekDaysArr.indexOf(day))
-                    console.log("day Num", dayNum)
+                    // console.log("dateAdjust", dateAdjust)
+                    // console.log(dispatchCheck)
+                    // console.log("baseday", baseDay)
+                    // console.log("index of this day", weekDaysArr.indexOf(day))
+                    // console.log("day Num", dayNum)
                     if(dateAdjust > (daysInMonth(d.getMonth() + advanceMonth)) && dispatchCheck === 1) {
                         const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + advanceMonth))
                        // console.log("endOfMonth", endOfMonth)
@@ -111,7 +112,7 @@ const InstCalandarView = () => {
         }
         
         );
-       
+   
     return (
         <div className={instructorCal.calContainer}>
             <div className={instructorCal.dateSlide}>

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -4,12 +4,12 @@ import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear } from '../../redux/weekNavSlice'
+import { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear, reverseYear } from '../../redux/weekNavSlice'
 
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const monthArr =['Jan', 'Feb', 'March', 'April', 'May', 'June', 'July', 'August', 'Sept', 'Oct', 'Nov', 'Dec']
-let dispatchCheck = 0
+let directionCheck = 1
 const InstCalandarView = () => {
 
     const [showLessonDet, setShowLessonDet] = useState(false);
@@ -28,7 +28,6 @@ const InstCalandarView = () => {
 
     const baseDay = useSelector(state => state.weekNav.baseDay)
     const month = useSelector(state => state.weekNav.month)
-    const advanceMonth = useSelector(state => state.weekNav.advanceMonth)
     const year = useSelector(state => state.weekNav.year)
     const dispatch = useDispatch()
     
@@ -40,37 +39,55 @@ const InstCalandarView = () => {
         const getDaysInMonth = (year, month) => {
             return new Date(year, month, 0).getDate();
         }
-        // const currentYear = d.getFullYear()
         const daysInMonth = (m) => {
             return getDaysInMonth(year, m + 1, 0)
         }
         
         const dayOfWeek = () => {
             const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-            
-            // console.log("dateAdjust", dateAdjust)
-            // console.log("baseday", baseDay)
-            // console.log("dayNum", dayNum)
-            // console.log("dispach Check", dispatchCheck)
-            console.log("days in", monthArr[month], daysInMonth(month))
+            const reverseDateAdjust = ((weekDaysArr.indexOf(day) + dayNum) - baseDay)
+          //  console.log("days in", monthArr[month], daysInMonth(month))
             if (weekDaysArr.indexOf(day) === dayNum) {  // For today
                 const today = baseDay 
                 console.log("today", today)
+                console.log("Today Direction Check", directionCheck)
+                if (today > daysInMonth(month)) {
+                    today -= daysInMonth(month)
+                    return today;
+                }
                 return today
 
-            } else if (weekDaysArr.indexOf(day) > dayNum) {  //For all days ahead of today
+            } else if (weekDaysArr.indexOf(day) > dayNum && directionCheck >= 0) {  //For all days ahead of today
                 const daysAhead = dateAdjust
                 console.log("daysAhead", daysAhead)
+                console.log("DaysAhead Direction Check", directionCheck)
                 if (daysAhead > daysInMonth(month)) { //At the end of the month when the days ahead of today are in the next month
                     daysAhead = daysAhead - daysInMonth(month) //the month is accurate
                     return daysAhead
                 }
-                
-
                 return daysAhead
-            } else if (weekDaysArr.indexOf(day) < dayNum) { //For all days behind today
+            } else if (weekDaysArr.indexOf(day) < dayNum && directionCheck >= 0) { //For all days behind today
                 const daysBehind = dateAdjust
-                console.log("daysBehind", daysBehind)
+                console.log("DasyBehind Direction Check", directionCheck)
+              //  console.log("daysBehind", daysBehind)
+                if (daysBehind <= 0) { //At the beginning of the month when the days behind today are in the last month 
+                    daysBehind += daysInMonth(month-1) //the month is accurate so last month is -1
+                    return daysBehind
+                }
+                return daysBehind
+            } else if (weekDaysArr.indexOf(day) < dayNum && directionCheck <= 0) {  //For all days ahead of today
+                const daysAhead = reverseDateAdjust
+                console.log("REVERSE daysAhead", daysAhead)
+                console.log(" REVERSE DaysAhead Direction Check", directionCheck)
+                if (daysAhead > daysInMonth(month)) { //At the end of the month when the days ahead of today are in the next month
+                    daysAhead = daysAhead - daysInMonth(month) //the month is accurate
+                    return daysAhead
+                }
+                return daysAhead
+            } else if (weekDaysArr.indexOf(day) > dayNum && directionCheck <= 0) { //For all days behind today
+                const daysBehind = dateAdjust -daysInMonth(month)
+                console.log("REVERSE DasyBehind Direction Check", directionCheck)
+              //  console.log("daysBehind", daysBehind)
                 if (daysBehind <= 0) { //At the beginning of the month when the days behind today are in the last month 
                     daysBehind += daysInMonth(month-1) //the month is accurate so last month is -1
                     return daysBehind
@@ -78,20 +95,21 @@ const InstCalandarView = () => {
                 return daysBehind
             }
             
-            
         }
        console.log(dayOfWeek())
         useEffect(() => {
-            if(dayOfWeek() > daysInMonth(month) && dispatchCheck > 0){ //mont is accurate
+            if(dayOfWeek() > daysInMonth(month) && directionCheck >= 0){ //month is accurate
                 dispatch(advanceMonthAdvance(1));
                 dispatch(advanceYear(1));
-                dispatchCheck=0;
-            } 
+                directionCheck=0;
+                console.log("USE EFFECT DIRECTION CHECK", directionCheck)
+            } else if (dayOfWeek() <= 1 && directionCheck < 0) {
+                dispatch(reverseMonthAdvance(1));
+                dispatch(reverseYear(1));
+                //directionCheck=0;
+                console.log("USE EFFECT DIRECTION CHECK", directionCheck)
+            }
             console.log("Month in USE EFFECT", monthArr[month])
-            // else if (dispatchCheck < 0) {
-            //     dispatch(reverseMonthAdvance(1));
-            
-            // }
         
         }, [baseDay]);
 
@@ -112,9 +130,10 @@ const InstCalandarView = () => {
             <div className={instructorCal.dateSlide}>
                 <button
                     onClick={() =>{
+                        directionCheck = -1;
                         dispatch(lastWeek(7))
-                        dispatchCheck = -1;
-                        return dispatchCheck;
+                        console.log("BACK directionCheck", directionCheck)
+                        return directionCheck;
                         }
                     }
                 >
@@ -125,10 +144,10 @@ const InstCalandarView = () => {
                 </label>
                 <button 
                     onClick={() =>{
+                        directionCheck = 1;
                         dispatch(nextWeek(7))
-                        dispatchCheck = 1;
-                        console.log("dispatchCheck", dispatchCheck)
-                        return dispatchCheck;
+                        console.log("FORWARD directionCheck", directionCheck)
+                        return directionCheck;
                         } 
                     }
                 >

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -47,33 +47,23 @@ const InstCalandarView = () => {
         const dayOfWeek = () => {
             
             if (weekDaysArr.indexOf(day) === dayNum) {
-                    //console.log("baseday", baseDay)
-                    
                     if(baseDay===0) {
                         const lastDay = daysInMonth(d.getMonth() + advanceMonth - 1)
                         return lastDay
                     }
-                    // console.log("index of this day", weekDaysArr.indexOf(day))
-                    // console.log("day Num", dayNum)
+                    console.log("baseday", baseDay)
                 return baseDay
-                } else {
+                } else if(dispatchCheck >= 0){
                     const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-                    // console.log("dateAdjust", dateAdjust)
-                    // console.log(dispatchCheck)
-                    // console.log("baseday", baseDay)
-                    // console.log("index of this day", weekDaysArr.indexOf(day))
-                    // console.log("day Num", dayNum)
+                    console.log("dispatch > 0")
                     if(dateAdjust > (daysInMonth(d.getMonth() + advanceMonth)) && dispatchCheck === 1) {
                         const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + advanceMonth))
-                       // console.log("endOfMonth", endOfMonth)
                         return endOfMonth
                     } else if (dateAdjust <= 0) { 
                         const negDay = ( dateAdjust + (daysInMonth(d.getMonth() + advanceMonth - 1)))
-                        //console.log("neg day", negDay)
                         return negDay;
                     } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth - 1) && dispatchCheck === 0) {
                         const startOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth - 1)
-                      //  console.log("start of Month", startOfMonth)
                         if (startOfMonth === 0) {
                             startOfMonth++
                         }
@@ -84,21 +74,30 @@ const InstCalandarView = () => {
     
                     }
                 return dateAdjust;
-            }
+            } else if(dispatchCheck < 0){
+                const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
+                //console.log("dateAdjust", dateAdjust)
+                if (dateAdjust <= 0) {
+                    console.log("startof month",monthArr[d.getMonth() + advanceMonth] )
+
+                    const startOfMonth = dateAdjust + daysInMonth(d.getMonth() + advanceMonth)
+                  
+                    return startOfMonth
+                }
+            return dateAdjust;
         }
-       
+        }
+       console.log("dayofWeek", dayOfWeek())
         useEffect(() => {
-            //console.log("In use Effect", dayOfWeek())
-            if(dayOfWeek() === 2) {
-                if(dispatchCheck > 0){
+                if(dispatchCheck > 0 && dayOfWeek() === 2){
                     dispatch(advanceMonthAdvance(1));
                     dispatch(advanceYear(1));
                     dispatchCheck=0;
-                } else if (dispatchCheck < 0) {
+                } else if (dispatchCheck < 0 && dayOfWeek() === 28) {
+                    console.log("reverse Month useeffect")
                     dispatch(reverseMonthAdvance(1));
-                
-                }
-            };
+                   // dispatchCheck = 0;
+                };
         }, [baseDay]);
 
         return (

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -44,53 +44,61 @@ const InstCalandarView = () => {
         const daysInMonth = (m) => {
             return getDaysInMonth(currentYear, m + 1, 0)
         }
+        const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay) 
+        
         const dayOfWeek = () => {
-            
+           // console.log("dateAdjust", dateAdjust)
             if (weekDaysArr.indexOf(day) === dayNum) {
-                    if(baseDay===0) {
-                        const lastDay = daysInMonth(d.getMonth() + advanceMonth - 1)
-                        return lastDay
-                    }
-                    console.log("baseday", baseDay)
+                // console.log("dayNum", dayNum)
+                // console.log("baseDay", baseDay)
+                // console.log("weekdayarr = dayNum")
+                if(baseDay===0) {
+                    const lastDay = daysInMonth(d.getMonth() + advanceMonth - 1) //advanceMonth is one behind so this is LAST month
+                    //console.log("baseday==0 lastday", lastDay)
+                    return lastDay
+                }
+       
                 return baseDay
-                } else if(dispatchCheck >= 0){
-                    const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-                    
-                    if(dateAdjust > (daysInMonth(d.getMonth() + advanceMonth)) && dispatchCheck === 1) {
-                        const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + advanceMonth))
-                        return endOfMonth
-                    } else if (dateAdjust <= 0) { 
-                        const negDay = ( dateAdjust + (daysInMonth(d.getMonth() + advanceMonth - 1)))
-                        return negDay;
-                    } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth - 1) && dispatchCheck === 0) {
-                        const startOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth - 1)
-                        if (startOfMonth === 0) {
-                            startOfMonth++
-                        }
-                        return startOfMonth;
-                    } else if (dateAdjust === 0) {
-                            const lastDay = (daysInMonth(d.getMonth() + advanceMonth))
-                            return lastDay;
-    
-                    }
+
+            } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth-1)) { //advance month is ahead
+                const startOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth-1)
+                // console.log("startofMonth", startOfMonth)
+                // console.log("SoM Days in Month", daysInMonth(d.getMonth() + advanceMonth-1))
+                // console.log("ADVANCE MONTH startofMonth", advanceMonth)
+                if (startOfMonth === 0) {
+                    startOfMonth++
+            //        console.log("startofMonth ++ ", startOfMonth)
+                }
+                return startOfMonth; 
+            // } else if (dateAdjust <= 0) { 
+            //     const negDay = ( dateAdjust + (daysInMonth(d.getMonth() + advanceMonth - 1)))
+            //     console.log("neg day", negDay)
+            //     return negDay;
+            // } else if(dateAdjust > daysInMonth(d.getMonth() + (advanceMonth - 1))) {
+            //     const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + (advanceMonth - 1)))
+            //     console.log("end of month", endOfMonth)
+            //     return endOfMonth
+            // } else if (dateAdjust === 0) {
+            //     const lastDay = (daysInMonth(d.getMonth() + advanceMonth))
+            //     console.log("date adjust == 0 lastday ", lastDay)
+            //     return lastDay;
+            } 
                 return dateAdjust;
-            } else if(dispatchCheck < 0){
-                const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-                console.log("dateAdjust", dateAdjust)
-            return dateAdjust;
-        }
+            
+            
         }
        
         useEffect(() => {
-           
-                if(dayOfWeek() === 2 && dispatchCheck > 0){
-                    dispatch(advanceMonthAdvance(1));
-                    dispatch(advanceYear(1));
-                    dispatchCheck=0;
-                } else if (dispatchCheck < 0) {
-                    dispatch(reverseMonthAdvance(1));
-                
-                }
+            if(dateAdjust === daysInMonth(d.getMonth() + advanceMonth + 1) && dispatchCheck > 0){ //advanceMonth is one behind
+                dispatch(advanceMonthAdvance(1));
+                dispatch(advanceYear(1));
+                dispatchCheck=0;
+            } 
+            console.log("advanceMonth in USE EFFECT", advanceMonth)
+            // else if (dispatchCheck < 0) {
+            //     dispatch(reverseMonthAdvance(1));
+            
+            // }
         
         }, [baseDay]);
 
@@ -113,7 +121,6 @@ const InstCalandarView = () => {
                     onClick={() =>{
                         dispatch(lastWeek(7))
                         dispatchCheck = -1;
-                        console.log("dispatch", dispatchCheck)
                         return dispatchCheck;
                         }
                     }
@@ -127,7 +134,7 @@ const InstCalandarView = () => {
                     onClick={() =>{
                         dispatch(nextWeek(7))
                         dispatchCheck = 1;
-                        console.log("dispatch", dispatchCheck)
+                        console.log("dispatchCheck", dispatchCheck)
                         return dispatchCheck;
                         } 
                     }

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -4,7 +4,8 @@ import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek, lastWeek, advanceMonthAdvance } from '../../redux/weekNavSlice'
+import { nextWeek, lastWeek, advanceMonthAdvance, advanceYear } from '../../redux/weekNavSlice'
+import { end } from '@popperjs/core';
 
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -28,6 +29,7 @@ const InstCalandarView = () => {
     const baseDay = useSelector(state => state.weekNav.baseDay)
     const month = useSelector(state => state.weekNav.month)
     const advanceMonth = useSelector(state => state.weekNav.advanceMonth)
+    const year = useSelector(state => state.weekNav.year)
     const dispatch = useDispatch()
    
 
@@ -48,27 +50,40 @@ const InstCalandarView = () => {
                 return baseDay
                 } else {
                     const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-                //    console.log("dateAdjust", dateAdjust)
-                    if (dateAdjust === 0) {
-                    //    console.log("zero day", daysInMonth(d.getMonth( ) + advanceMonth))
-                        const lastDay = (daysInMonth(d.getMonth() + advanceMonth))
-                        
-                    //    console.log("last day advance", advanceMonth)
-                        return lastDay;
+                    console.log("dateAdjust", dateAdjust)
+                    // console.log("baseday", baseDay)
+                    // console.log("daynum", dayNum)
+                    // console.log("weedayArr.index(day)-dayNum + base", ((weekDaysArr.indexOf(day) - dayNum) + baseDay))
+                    if (dateAdjust < 0) {
+                        const negDay = ( dateAdjust + (daysInMonth(d.getMonth() + advanceMonth - 1)))
+                        return negDay;
 
                     } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth)) {
-                        const endOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth)
+                        const endOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth - 1)
+                        console.log("end of month", endOfMonth)
+                        if (endOfMonth === 0) {
+                            endOfMonth++
+                        }
                         return endOfMonth;
+                    } else if (dateAdjust === 0) {
+                           console.log("zero day", daysInMonth(d.getMonth( ) + advanceMonth -1 ))
+                            const lastDay = (daysInMonth(d.getMonth() + advanceMonth -1))
+                            console.log("last day", lastDay)
+                        //    console.log("last day advance", advanceMonth)
+                            return lastDay;
+    
                     }
                 return dateAdjust;
             }
         }
         // console.log("day of month", dayOfMonth())
+        console.log("last days in month", daysInMonth(d.getMonth() + advanceMonth))
         useEffect(() => {
-            if(dayOfMonth() === 1) {
-                console.log("update advancemonth")
+            if(dayOfMonth() === 2) {
+                console.log("did")
                 // advanceMonth++
-                dispatch(advanceMonthAdvance(1))
+                dispatch(advanceMonthAdvance(1));
+                dispatch(advanceYear(1));
             };
         }, [dayOfMonth()]);
 
@@ -100,7 +115,7 @@ const InstCalandarView = () => {
                 >
                     aro
                 </button>
-                <label>{month}</label>
+                <label>{month} {year}</label>
             </div>
             <div className={instructorCal.weekContainer}>
                 {weekDays}

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -42,48 +42,36 @@ const InstCalandarView = () => {
         const daysInMonth = (m) => {
             return getDaysInMonth(currentYear, m + 1, 0)
         }
-       
         const dayOfMonth = () => {
             if (weekDaysArr.indexOf(day) === dayNum) {
-               // console.log("baseDay", baseDay)
+            //    console.log("baseDay", baseDay)
                 return baseDay
                 } else {
                     const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-                   // console.log("dateAdjust", dateAdjust)
+                //    console.log("dateAdjust", dateAdjust)
                     if (dateAdjust === 0) {
-                       // console.log("zero day", daysInMonth(d.getMonth( ) + advanceMonth))
+                    //    console.log("zero day", daysInMonth(d.getMonth( ) + advanceMonth))
                         const lastDay = (daysInMonth(d.getMonth() + advanceMonth))
-                       // console.log("last day advance", advanceMonth)
+                        
+                    //    console.log("last day advance", advanceMonth)
                         return lastDay;
 
                     } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth)) {
                         const endOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth)
                         return endOfMonth;
                     }
-                    // if  (dateAdjust >= (daysInMonth(d.getMonth() + advanceMonth))) {
-                        
-                    //     dateAdjust = dateAdjust - daysInMonth(d.getMonth() + advanceMonth)
-                    //     console.log("else if", dateAdjust, advanceMonth)   
-
-                    //     if (dateAdjust <= 0) {
-                    //         dispatch(advanceMonthAdvance(1))
-                    //         dateAdjust = daysInMonth(d.getMonth() + advanceMonth)
-                           
-                    //         console.log("next month", dateAdjust, advanceMonth)                    
-                    //         return dateAdjust 
-                    //         } else {
-                    //             return dateAdjust;
-                    //         }
-                    // } 
                 return dateAdjust;
             }
         }
-        console.log("day of month", dayOfMonth())
-        if(dayOfMonth() === 1) {
-            console.log("update advancemonth")
-            advanceMonth++
-           // return dispatch(advanceMonthAdvance(1))
-        };
+        // console.log("day of month", dayOfMonth())
+        useEffect(() => {
+            if(dayOfMonth() === 1) {
+                console.log("update advancemonth")
+                // advanceMonth++
+                dispatch(advanceMonthAdvance(1))
+            };
+        }, [dayOfMonth()]);
+
         return (
         <div 
             className={instructorCal.dayContainer} 

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -5,6 +5,7 @@ import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesso
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
 import { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear } from '../../redux/weekNavSlice'
+import { end, start } from '@popperjs/core';
 
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -44,17 +45,34 @@ const InstCalandarView = () => {
             return getDaysInMonth(currentYear, m + 1, 0)
         }
         const dayOfWeek = () => {
+            
             if (weekDaysArr.indexOf(day) === dayNum) {
+                    //console.log("baseday", baseDay)
+                    if(baseDay===0) {
+                        const lastDay = daysInMonth(d.getMonth() + advanceMonth - 1)
+                        return lastDay
+                    }
+                    // console.log("index of this day", weekDaysArr.indexOf(day))
+                    // console.log("day Num", dayNum)
                 return baseDay
                 } else {
                     const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
                     console.log("dateAdjust", dateAdjust)
-                    console.log("greater than days in this month",daysInMonth(d.getMonth() + advanceMonth - 1))
-                    if (dateAdjust < 0) {
+                    console.log(dispatchCheck)
+                    console.log("baseday", baseDay)
+                    console.log("index of this day", weekDaysArr.indexOf(day))
+                    console.log("day Num", dayNum)
+                    if(dateAdjust > (daysInMonth(d.getMonth() + advanceMonth)) && dispatchCheck === 1) {
+                        const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + advanceMonth))
+                       // console.log("endOfMonth", endOfMonth)
+                        return endOfMonth
+                    } else if (dateAdjust <= 0) { 
                         const negDay = ( dateAdjust + (daysInMonth(d.getMonth() + advanceMonth - 1)))
+                        //console.log("neg day", negDay)
                         return negDay;
-                    } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth - 1)) {
+                    } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth - 1) && dispatchCheck === 0) {
                         const startOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth - 1)
+                      //  console.log("start of Month", startOfMonth)
                         if (startOfMonth === 0) {
                             startOfMonth++
                         }
@@ -70,11 +88,12 @@ const InstCalandarView = () => {
        
         useEffect(() => {
             //console.log("In use Effect", dayOfWeek())
-            if(dayOfWeek() === 1) {
+            if(dayOfWeek() === 2) {
                 if(dispatchCheck > 0){
                     dispatch(advanceMonthAdvance(1));
-                    dispatch(advanceYear(1));}
-                else if (dispatchCheck < 0) {
+                    dispatch(advanceYear(1));
+                    dispatchCheck=0;
+                } else if (dispatchCheck < 0) {
                     dispatch(reverseMonthAdvance(1));
                 
                 }

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -1,11 +1,10 @@
-import React, { useState} from 'react';
+import React, { useState, useEffect} from 'react';
 import instructorCal from '../../styles/instructorCal.module.scss';
 import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek } from '../../redux/weekNavSlice'
-
+import { nextWeek, lastWeek } from '../../redux/weekNavSlice'
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
@@ -24,23 +23,43 @@ const InstCalandarView = () => {
                 }
             });
     }
-        
-    const today = useSelector((state) => state.weekNav.today)
+
+   
+   
+
+    const today = useSelector(state => state.weekNav.today)
+    const nextMonth = useSelector(state => state.weekNav.nextMonth)
     const dispatch = useDispatch()
 
     const weekDays = weekDaysArr.map(function(day) {
-      
-        let d = new Date();
+        
+        const d = new Date();
+        const dayNum = d.getDay()
+        const getDaysInMonth = (year, month) => {
+            return new Date(year, month, 0).getDate();
+        }
+        const currentYear = d.getFullYear()
+        const daysInMonth = (m) => {
+            return getDaysInMonth(currentYear, m + 1, 0)
+        }
+       
         const dayOfWeek = () => {
             for (let i=0; i < 7; i++) {
-                if (weekDaysArr.indexOf(day) === today) {
-                return d.getDate()
+                if (weekDaysArr.indexOf(day) === dayNum) {
+                return today
                 } else {
-                    return ((weekDaysArr.indexOf(day) - today) + d.getDate())
-                }
+                    const endOfMonth = ((weekDaysArr.indexOf(day) - dayNum) + today)
+                    if (endOfMonth <= 0) {
+                        endOfMonth = daysInMonth(d.getMonth() + nextMonth)
+                        console.log("next month", nextMonth)
+                        return endOfMonth
+                    }
 
-            } 
+                    return (endOfMonth)
+                }
+            }
         }
+        
         return (
         <div 
             className={instructorCal.dayContainer} 
@@ -49,19 +68,23 @@ const InstCalandarView = () => {
             {day}{dayOfWeek()}
             <InstCalandarDay handleLessonDet={handleLessonDet}/>
         </div>)
-        });
-
-  
-        console.log(today)
+        }
+        
+        );
+        
     return (
         <div className={instructorCal.calContainer}>
             <div className={instructorCal.dateSlide}>
-                <button>aro</button>
+                <button
+                    onClick={() =>dispatch(lastWeek(7))}
+                >
+                    aro
+                </button>
                 <label className={instructorCal.slideText}>
                     {today}
                 </label>
                 <button 
-                    onClick={() =>dispatch(nextWeek())}
+                    onClick={() =>dispatch(nextWeek(7))}
                 >
                     aro
                 </button>
@@ -76,6 +99,7 @@ const InstCalandarView = () => {
             </div>
         </div>
         )
+      
     }
 
 export default InstCalandarView

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -40,59 +40,43 @@ const InstCalandarView = () => {
         const getDaysInMonth = (year, month) => {
             return new Date(year, month, 0).getDate();
         }
-        const currentYear = d.getFullYear()
+        // const currentYear = d.getFullYear()
         const daysInMonth = (m) => {
-            return getDaysInMonth(currentYear, m + 1, 0)
+            return getDaysInMonth(year, m + 1, 0)
         }
         
         const dayOfWeek = () => {
-            const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay) 
-            console.log("dateAdjust", dateAdjust)
-            console.log(baseDay)
-            console.log("dayNum", dayNum)
-            if (weekDaysArr.indexOf(day) === dayNum) {
-                // console.log("dayNum", dayNum)
-                // console.log("baseDay", baseDay)
-                // console.log("weekdayarr = dayNum")
-                // if(baseDay===0) {
-                //     const lastDay = daysInMonth(month) //advanceMonth accurate
-                //     console.log("baseday==0 lastday", lastDay)
-                //     return lastDay
-                // }
-                return baseDay
+            const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
+            
+            // console.log("dateAdjust", dateAdjust)
+            // console.log("baseday", baseDay)
+            // console.log("dayNum", dayNum)
+            // console.log("dispach Check", dispatchCheck)
+            console.log("days in", monthArr[month], daysInMonth(month))
+            if (weekDaysArr.indexOf(day) === dayNum) {  // For today
+                const today = baseDay 
+                console.log("today", today)
+                return today
 
-            } else if (weekDaysArr.indexOf(day) > dayNum) {
+            } else if (weekDaysArr.indexOf(day) > dayNum) {  //For all days ahead of today
                 const daysAhead = dateAdjust
-                if (daysAhead > daysInMonth(month)) {
-                    daysAhead = daysAhead - daysInMonth(month)
+                console.log("daysAhead", daysAhead)
+                if (daysAhead > daysInMonth(month)) { //At the end of the month when the days ahead of today are in the next month
+                    daysAhead = daysAhead - daysInMonth(month) //the month is accurate
+                    return daysAhead
                 }
+                
 
                 return daysAhead
-            } else if (weekDaysArr.indexOf(day) < dayNum) {
+            } else if (weekDaysArr.indexOf(day) < dayNum) { //For all days behind today
                 const daysBehind = dateAdjust
+                console.log("daysBehind", daysBehind)
+                if (daysBehind <= 0) { //At the beginning of the month when the days behind today are in the last month 
+                    daysBehind += daysInMonth(month-1) //the month is accurate so last month is -1
+                    return daysBehind
+                }
                 return daysBehind
             }
-            //  else if (dateAdjust > daysInMonth(month)) { //advance acurate
-            //     const startOfMonth = dateAdjust - daysInMonth(month)
-            //     console.log("startofMonth", startOfMonth)
-            //     console.log("SoM Days in THIS Month", daysInMonth(month))
-            //     console.log(" MONTH startofMonth", monthArr[month])
-               
-            //     return startOfMonth; 
-            // // } else if (dateAdjust <= 0) { 
-            // //     const negDay = ( dateAdjust + (daysInMonth(month - 1)))
-            // //     console.log("neg day", negDay)
-            // //     return negDay;
-            // // } else if(dateAdjust > daysInMonth(d.getMonth() + (advanceMonth - 1))) {
-            // //     const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + (advanceMonth - 1)))
-            // //     console.log("end of month", endOfMonth)
-            // //     return endOfMonth
-            // // } else if (dateAdjust === 0) {
-            // //     const lastDay = (daysInMonth(month))
-            // //     console.log("date adjust == 0 lastday ", lastDay)
-            // //     return lastDay;
-            // } 
-            //     return dateAdjust;
             
             
         }
@@ -103,7 +87,7 @@ const InstCalandarView = () => {
                 dispatch(advanceYear(1));
                 dispatchCheck=0;
             } 
-            console.log("Month in USE EFFECT", month)
+            console.log("Month in USE EFFECT", monthArr[month])
             // else if (dispatchCheck < 0) {
             //     dispatch(reverseMonthAdvance(1));
             

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -4,18 +4,15 @@ import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek } from '../../redux/calandarDataSlice'
+import { nextWeek, startingDate } from '../../redux/calandarDataSlice'
+import { arrow } from '@popperjs/core';
 
 
-const weekDaysArr = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 const InstCalandarView = () => {
 
     const [showLessonDet, setShowLessonDet] = useState(false);
-
-    // useEffect(() => {
-    //     console.log("Show Lesson Det is now:", showLessonDet);
-    // }, [showLessonDet]);
 
     const handleLessonDet = (e) => {
             e.preventDefault();
@@ -28,24 +25,37 @@ const InstCalandarView = () => {
                 }
             });
     }
-    
-    const weekDays = weekDaysArr.map((day) =>
+        
+    const weekDays = weekDaysArr.map(function(day) {
+        const d = new Date();
+        const dayNum = d.getDay();
+
+        const dayOfWeek = () => {
+            for (let i=0; i < 7; i++) {
+                if (weekDaysArr.indexOf(day) === dayNum) {
+                return d.getDate()
+                } else {
+                    return ((weekDaysArr.indexOf(day) - dayNum) + d.getDate())
+                }
+
+            } 
+        }
+        return (
         <div 
             className={instructorCal.dayContainer} 
             key={day.toString()}
         >
-            {day}
+            {day}{dayOfWeek()}
             <InstCalandarDay handleLessonDet={handleLessonDet}/>
-        </div>
-        )
+        </div>)
+        });
 
-        const today = useSelector((state) => state.calandarData.date)
-        const year = useSelector((state) => state.calandarData.year)
-        const month = useSelector((state) => state.calandarData.month)
-        const dispatch = useDispatch()
-       
-        const startingDate = new Date(year, month, 1)
-        console.log("starting Date", startingDate)
+    const d = new Date();
+    const today =  (d.getMonth() + " " + d.getDay() + " " + d.getDate())
+  
+
+    const day = useSelector((state) => state.calandarData.day)
+    const dispatch = useDispatch()
 
     return (
         <div className={instructorCal.calContainer}>
@@ -59,6 +69,7 @@ const InstCalandarView = () => {
                 >
                     aro
                 </button>
+                <label>{day}</label>
             </div>
             <div className={instructorCal.weekContainer}>
                 {weekDays}

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -4,14 +4,14 @@ import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek, lastWeek, nextMonthAdvance } from '../../redux/weekNavSlice'
+import { nextWeek, lastWeek, advanceMonthAdvance } from '../../redux/weekNavSlice'
+
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 const InstCalandarView = () => {
 
     const [showLessonDet, setShowLessonDet] = useState(false);
-
 
     const handleLessonDet = (e) => {
             e.preventDefault();
@@ -25,11 +25,12 @@ const InstCalandarView = () => {
             });
     }
 
-    const today = useSelector(state => state.weekNav.today)
-    const nextMonth = useSelector(state => state.weekNav.nextMonth)
+    const baseDay = useSelector(state => state.weekNav.baseDay)
+    const month = useSelector(state => state.weekNav.month)
+    const advanceMonth = useSelector(state => state.weekNav.advanceMonth)
     const dispatch = useDispatch()
+   
 
-    const once = false;
     const weekDays = weekDaysArr.map(function(day) {
         
         const d = new Date();
@@ -42,25 +43,53 @@ const InstCalandarView = () => {
             return getDaysInMonth(currentYear, m + 1, 0)
         }
        
-        const dayOfWeek = () => {
+        const dayOfMonth = () => {
             if (weekDaysArr.indexOf(day) === dayNum) {
-                return today
+               // console.log("baseDay", baseDay)
+                return baseDay
                 } else {
-                    const endOfMonth = ((weekDaysArr.indexOf(day) - dayNum) + today)
-                    if (endOfMonth <= 0) {
-                        endOfMonth = daysInMonth(d.getMonth() + nextMonth)
-                        console.log("next month", nextMonth)                        
-                        endOfMonth 
+                    const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
+                   // console.log("dateAdjust", dateAdjust)
+                    if (dateAdjust === 0) {
+                       // console.log("zero day", daysInMonth(d.getMonth( ) + advanceMonth))
+                        const lastDay = (daysInMonth(d.getMonth() + advanceMonth))
+                       // console.log("last day advance", advanceMonth)
+                        return lastDay;
+
+                    } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth)) {
+                        const endOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth)
+                        return endOfMonth;
                     }
-                return endOfMonth
+                    // if  (dateAdjust >= (daysInMonth(d.getMonth() + advanceMonth))) {
+                        
+                    //     dateAdjust = dateAdjust - daysInMonth(d.getMonth() + advanceMonth)
+                    //     console.log("else if", dateAdjust, advanceMonth)   
+
+                    //     if (dateAdjust <= 0) {
+                    //         dispatch(advanceMonthAdvance(1))
+                    //         dateAdjust = daysInMonth(d.getMonth() + advanceMonth)
+                           
+                    //         console.log("next month", dateAdjust, advanceMonth)                    
+                    //         return dateAdjust 
+                    //         } else {
+                    //             return dateAdjust;
+                    //         }
+                    // } 
+                return dateAdjust;
             }
         }
+        console.log("day of month", dayOfMonth())
+        if(dayOfMonth() === 1) {
+            console.log("update advancemonth")
+            advanceMonth++
+           // return dispatch(advanceMonthAdvance(1))
+        };
         return (
         <div 
             className={instructorCal.dayContainer} 
             key={day.toString()}
         >
-            {day}{dayOfWeek()}
+            {day}{dayOfMonth()}
             <InstCalandarDay handleLessonDet={handleLessonDet}/>
         </div>)
         }
@@ -71,19 +100,19 @@ const InstCalandarView = () => {
         <div className={instructorCal.calContainer}>
             <div className={instructorCal.dateSlide}>
                 <button
-                    onClick={() =>dispatch(lastWeek(7))}
+                    onClick={() =>dispatch(advanceMonthAdvance(1))}
                 >
                     aro
                 </button>
                 <label className={instructorCal.slideText}>
-                    {today}
+                    {baseDay}
                 </label>
                 <button 
                     onClick={() =>dispatch(nextWeek(7))}
                 >
                     aro
                 </button>
-                <label>hi</label>
+                <label>{month}</label>
             </div>
             <div className={instructorCal.weekContainer}>
                 {weekDays}

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -4,13 +4,14 @@ import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek, lastWeek } from '../../redux/weekNavSlice'
+import { nextWeek, lastWeek, nextMonthAdvance } from '../../redux/weekNavSlice'
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 const InstCalandarView = () => {
 
     const [showLessonDet, setShowLessonDet] = useState(false);
+
 
     const handleLessonDet = (e) => {
             e.preventDefault();
@@ -24,13 +25,11 @@ const InstCalandarView = () => {
             });
     }
 
-   
-   
-
     const today = useSelector(state => state.weekNav.today)
     const nextMonth = useSelector(state => state.weekNav.nextMonth)
     const dispatch = useDispatch()
 
+    const once = false;
     const weekDays = weekDaysArr.map(function(day) {
         
         const d = new Date();
@@ -44,22 +43,18 @@ const InstCalandarView = () => {
         }
        
         const dayOfWeek = () => {
-            for (let i=0; i < 7; i++) {
-                if (weekDaysArr.indexOf(day) === dayNum) {
+            if (weekDaysArr.indexOf(day) === dayNum) {
                 return today
                 } else {
                     const endOfMonth = ((weekDaysArr.indexOf(day) - dayNum) + today)
                     if (endOfMonth <= 0) {
                         endOfMonth = daysInMonth(d.getMonth() + nextMonth)
-                        console.log("next month", nextMonth)
-                        return endOfMonth
+                        console.log("next month", nextMonth)                        
+                        endOfMonth 
                     }
-
-                    return (endOfMonth)
-                }
+                return endOfMonth
             }
         }
-        
         return (
         <div 
             className={instructorCal.dayContainer} 

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -1,11 +1,10 @@
-import React, {useEffect, useState} from 'react';
+import React, { useState} from 'react';
 import instructorCal from '../../styles/instructorCal.module.scss';
 import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek, startingDate } from '../../redux/calandarDataSlice'
-import { arrow } from '@popperjs/core';
+import { nextWeek } from '../../redux/weekNavSlice'
 
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -26,16 +25,18 @@ const InstCalandarView = () => {
             });
     }
         
-    const weekDays = weekDaysArr.map(function(day) {
-        const d = new Date();
-        const dayNum = d.getDay();
+    const today = useSelector((state) => state.weekNav.today)
+    const dispatch = useDispatch()
 
+    const weekDays = weekDaysArr.map(function(day) {
+      
+        let d = new Date();
         const dayOfWeek = () => {
             for (let i=0; i < 7; i++) {
-                if (weekDaysArr.indexOf(day) === dayNum) {
+                if (weekDaysArr.indexOf(day) === today) {
                 return d.getDate()
                 } else {
-                    return ((weekDaysArr.indexOf(day) - dayNum) + d.getDate())
+                    return ((weekDaysArr.indexOf(day) - today) + d.getDate())
                 }
 
             } 
@@ -50,13 +51,8 @@ const InstCalandarView = () => {
         </div>)
         });
 
-    const d = new Date();
-    const today =  (d.getMonth() + " " + d.getDay() + " " + d.getDate())
   
-
-    const day = useSelector((state) => state.calandarData.day)
-    const dispatch = useDispatch()
-
+        console.log(today)
     return (
         <div className={instructorCal.calContainer}>
             <div className={instructorCal.dateSlide}>
@@ -69,7 +65,7 @@ const InstCalandarView = () => {
                 >
                     aro
                 </button>
-                <label>{day}</label>
+                <label>hi</label>
             </div>
             <div className={instructorCal.weekContainer}>
                 {weekDays}

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -47,33 +47,23 @@ const InstCalandarView = () => {
         const dayOfWeek = () => {
             
             if (weekDaysArr.indexOf(day) === dayNum) {
-                    //console.log("baseday", baseDay)
-                    
                     if(baseDay===0) {
                         const lastDay = daysInMonth(d.getMonth() + advanceMonth - 1)
                         return lastDay
                     }
-                    // console.log("index of this day", weekDaysArr.indexOf(day))
-                    // console.log("day Num", dayNum)
+                    console.log("baseday", baseDay)
                 return baseDay
-                } else {
+                } else if(dispatchCheck >= 0){
                     const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-                    // console.log("dateAdjust", dateAdjust)
-                    // console.log(dispatchCheck)
-                    // console.log("baseday", baseDay)
-                    // console.log("index of this day", weekDaysArr.indexOf(day))
-                    // console.log("day Num", dayNum)
+                    
                     if(dateAdjust > (daysInMonth(d.getMonth() + advanceMonth)) && dispatchCheck === 1) {
                         const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + advanceMonth))
-                       // console.log("endOfMonth", endOfMonth)
                         return endOfMonth
                     } else if (dateAdjust <= 0) { 
                         const negDay = ( dateAdjust + (daysInMonth(d.getMonth() + advanceMonth - 1)))
-                        //console.log("neg day", negDay)
                         return negDay;
                     } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth - 1) && dispatchCheck === 0) {
                         const startOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth - 1)
-                      //  console.log("start of Month", startOfMonth)
                         if (startOfMonth === 0) {
                             startOfMonth++
                         }
@@ -84,13 +74,16 @@ const InstCalandarView = () => {
     
                     }
                 return dateAdjust;
-            }
+            } else if(dispatchCheck < 0){
+                const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
+                console.log("dateAdjust", dateAdjust)
+            return dateAdjust;
+        }
         }
        
         useEffect(() => {
-            //console.log("In use Effect", dayOfWeek())
-            if(dayOfWeek() === 2) {
-                if(dispatchCheck > 0){
+           
+                if(dayOfWeek() === 2 && dispatchCheck > 0){
                     dispatch(advanceMonthAdvance(1));
                     dispatch(advanceYear(1));
                     dispatchCheck=0;
@@ -98,7 +91,7 @@ const InstCalandarView = () => {
                     dispatch(reverseMonthAdvance(1));
                 
                 }
-            };
+        
         }, [baseDay]);
 
         return (

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -44,57 +44,66 @@ const InstCalandarView = () => {
         const daysInMonth = (m) => {
             return getDaysInMonth(currentYear, m + 1, 0)
         }
-        const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay) 
         
         const dayOfWeek = () => {
-           // console.log("dateAdjust", dateAdjust)
+            const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay) 
+            console.log("dateAdjust", dateAdjust)
+            console.log(baseDay)
+            console.log("dayNum", dayNum)
             if (weekDaysArr.indexOf(day) === dayNum) {
                 // console.log("dayNum", dayNum)
                 // console.log("baseDay", baseDay)
                 // console.log("weekdayarr = dayNum")
-                if(baseDay===0) {
-                    const lastDay = daysInMonth(d.getMonth() + advanceMonth - 1) //advanceMonth is one behind so this is LAST month
-                    //console.log("baseday==0 lastday", lastDay)
-                    return lastDay
-                }
-       
+                // if(baseDay===0) {
+                //     const lastDay = daysInMonth(month) //advanceMonth accurate
+                //     console.log("baseday==0 lastday", lastDay)
+                //     return lastDay
+                // }
                 return baseDay
 
-            } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth-1)) { //advance month is ahead
-                const startOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth-1)
-                // console.log("startofMonth", startOfMonth)
-                // console.log("SoM Days in Month", daysInMonth(d.getMonth() + advanceMonth-1))
-                // console.log("ADVANCE MONTH startofMonth", advanceMonth)
-                if (startOfMonth === 0) {
-                    startOfMonth++
-            //        console.log("startofMonth ++ ", startOfMonth)
+            } else if (weekDaysArr.indexOf(day) > dayNum) {
+                const daysAhead = dateAdjust
+                if (daysAhead > daysInMonth(month)) {
+                    daysAhead = daysAhead - daysInMonth(month)
                 }
-                return startOfMonth; 
-            // } else if (dateAdjust <= 0) { 
-            //     const negDay = ( dateAdjust + (daysInMonth(d.getMonth() + advanceMonth - 1)))
-            //     console.log("neg day", negDay)
-            //     return negDay;
-            // } else if(dateAdjust > daysInMonth(d.getMonth() + (advanceMonth - 1))) {
-            //     const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + (advanceMonth - 1)))
-            //     console.log("end of month", endOfMonth)
-            //     return endOfMonth
-            // } else if (dateAdjust === 0) {
-            //     const lastDay = (daysInMonth(d.getMonth() + advanceMonth))
-            //     console.log("date adjust == 0 lastday ", lastDay)
-            //     return lastDay;
-            } 
-                return dateAdjust;
+
+                return daysAhead
+            } else if (weekDaysArr.indexOf(day) < dayNum) {
+                const daysBehind = dateAdjust
+                return daysBehind
+            }
+            //  else if (dateAdjust > daysInMonth(month)) { //advance acurate
+            //     const startOfMonth = dateAdjust - daysInMonth(month)
+            //     console.log("startofMonth", startOfMonth)
+            //     console.log("SoM Days in THIS Month", daysInMonth(month))
+            //     console.log(" MONTH startofMonth", monthArr[month])
+               
+            //     return startOfMonth; 
+            // // } else if (dateAdjust <= 0) { 
+            // //     const negDay = ( dateAdjust + (daysInMonth(month - 1)))
+            // //     console.log("neg day", negDay)
+            // //     return negDay;
+            // // } else if(dateAdjust > daysInMonth(d.getMonth() + (advanceMonth - 1))) {
+            // //     const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + (advanceMonth - 1)))
+            // //     console.log("end of month", endOfMonth)
+            // //     return endOfMonth
+            // // } else if (dateAdjust === 0) {
+            // //     const lastDay = (daysInMonth(month))
+            // //     console.log("date adjust == 0 lastday ", lastDay)
+            // //     return lastDay;
+            // } 
+            //     return dateAdjust;
             
             
         }
-       
+       console.log(dayOfWeek())
         useEffect(() => {
-            if(dateAdjust === daysInMonth(d.getMonth() + advanceMonth + 1) && dispatchCheck > 0){ //advanceMonth is one behind
+            if(dayOfWeek() > daysInMonth(month) && dispatchCheck > 0){ //mont is accurate
                 dispatch(advanceMonthAdvance(1));
                 dispatch(advanceYear(1));
                 dispatchCheck=0;
             } 
-            console.log("advanceMonth in USE EFFECT", advanceMonth)
+            console.log("Month in USE EFFECT", month)
             // else if (dispatchCheck < 0) {
             //     dispatch(reverseMonthAdvance(1));
             
@@ -141,7 +150,7 @@ const InstCalandarView = () => {
                 >
                     aro
                 </button>
-                <label>{month} {year}</label>
+                <label>{monthArr[month]} {year}</label>
             </div>
             <div className={instructorCal.weekContainer}>
                 {weekDays}

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -4,12 +4,11 @@ import InstCalandarDay from './instCal-day';
 import InstructorLessonDetail from '../instructor-lesson-detail/instructor-lesson-detail';
 import LessonCalControl from './lesson-calandar-control';
 import { useSelector, useDispatch } from 'react-redux';
-import { nextWeek, lastWeek, advanceMonthAdvance, advanceYear } from '../../redux/weekNavSlice'
-import { end } from '@popperjs/core';
+import { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear } from '../../redux/weekNavSlice'
 
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-
+let dispatchCheck = 0
 const InstCalandarView = () => {
 
     const [showLessonDet, setShowLessonDet] = useState(false);
@@ -34,7 +33,7 @@ const InstCalandarView = () => {
    
 
     const weekDays = weekDaysArr.map(function(day) {
-        
+   
         const d = new Date();
         const dayNum = d.getDay()
         const getDaysInMonth = (year, month) => {
@@ -44,66 +43,67 @@ const InstCalandarView = () => {
         const daysInMonth = (m) => {
             return getDaysInMonth(currentYear, m + 1, 0)
         }
-        const dayOfMonth = () => {
+        const dayOfWeek = () => {
             if (weekDaysArr.indexOf(day) === dayNum) {
-            //    console.log("baseDay", baseDay)
                 return baseDay
                 } else {
                     const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
                     console.log("dateAdjust", dateAdjust)
-                    // console.log("baseday", baseDay)
-                    // console.log("daynum", dayNum)
-                    // console.log("weedayArr.index(day)-dayNum + base", ((weekDaysArr.indexOf(day) - dayNum) + baseDay))
+                    console.log("greater than days in this month",daysInMonth(d.getMonth() + advanceMonth - 1))
                     if (dateAdjust < 0) {
                         const negDay = ( dateAdjust + (daysInMonth(d.getMonth() + advanceMonth - 1)))
                         return negDay;
-
-                    } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth)) {
-                        const endOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth - 1)
-                        console.log("end of month", endOfMonth)
-                        if (endOfMonth === 0) {
-                            endOfMonth++
+                    } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth - 1)) {
+                        const startOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth - 1)
+                        if (startOfMonth === 0) {
+                            startOfMonth++
                         }
-                        return endOfMonth;
+                        return startOfMonth;
                     } else if (dateAdjust === 0) {
-                           console.log("zero day", daysInMonth(d.getMonth( ) + advanceMonth -1 ))
-                            const lastDay = (daysInMonth(d.getMonth() + advanceMonth -1))
-                            console.log("last day", lastDay)
-                        //    console.log("last day advance", advanceMonth)
+                            const lastDay = (daysInMonth(d.getMonth() + advanceMonth))
                             return lastDay;
     
                     }
                 return dateAdjust;
             }
         }
-        // console.log("day of month", dayOfMonth())
-        console.log("last days in month", daysInMonth(d.getMonth() + advanceMonth))
+       
         useEffect(() => {
-            if(dayOfMonth() === 2) {
-                console.log("did")
-                // advanceMonth++
-                dispatch(advanceMonthAdvance(1));
-                dispatch(advanceYear(1));
+            //console.log("In use Effect", dayOfWeek())
+            if(dayOfWeek() === 1) {
+                if(dispatchCheck > 0){
+                    dispatch(advanceMonthAdvance(1));
+                    dispatch(advanceYear(1));}
+                else if (dispatchCheck < 0) {
+                    dispatch(reverseMonthAdvance(1));
+                
+                }
             };
-        }, [dayOfMonth()]);
+        }, [baseDay]);
 
         return (
         <div 
             className={instructorCal.dayContainer} 
             key={day.toString()}
         >
-            {day}{dayOfMonth()}
+            {day}{dayOfWeek()}
             <InstCalandarDay handleLessonDet={handleLessonDet}/>
         </div>)
         }
         
         );
-        
+       
     return (
         <div className={instructorCal.calContainer}>
             <div className={instructorCal.dateSlide}>
                 <button
-                    onClick={() =>dispatch(advanceMonthAdvance(1))}
+                    onClick={() =>{
+                        dispatch(lastWeek(7))
+                        dispatchCheck = -1;
+                        console.log("dispatch", dispatchCheck)
+                        return dispatchCheck;
+                        }
+                    }
                 >
                     aro
                 </button>
@@ -111,7 +111,13 @@ const InstCalandarView = () => {
                     {baseDay}
                 </label>
                 <button 
-                    onClick={() =>dispatch(nextWeek(7))}
+                    onClick={() =>{
+                        dispatch(nextWeek(7))
+                        dispatchCheck = 1;
+                        console.log("dispatch", dispatchCheck)
+                        return dispatchCheck;
+                        } 
+                    }
                 >
                     aro
                 </button>

--- a/components/instructor-calandar-view/instructor-calandar-view.js
+++ b/components/instructor-calandar-view/instructor-calandar-view.js
@@ -47,23 +47,33 @@ const InstCalandarView = () => {
         const dayOfWeek = () => {
             
             if (weekDaysArr.indexOf(day) === dayNum) {
+                    //console.log("baseday", baseDay)
+                    
                     if(baseDay===0) {
                         const lastDay = daysInMonth(d.getMonth() + advanceMonth - 1)
                         return lastDay
                     }
-                    console.log("baseday", baseDay)
+                    // console.log("index of this day", weekDaysArr.indexOf(day))
+                    // console.log("day Num", dayNum)
                 return baseDay
-                } else if(dispatchCheck >= 0){
+                } else {
                     const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-                    console.log("dispatch > 0")
+                    // console.log("dateAdjust", dateAdjust)
+                    // console.log(dispatchCheck)
+                    // console.log("baseday", baseDay)
+                    // console.log("index of this day", weekDaysArr.indexOf(day))
+                    // console.log("day Num", dayNum)
                     if(dateAdjust > (daysInMonth(d.getMonth() + advanceMonth)) && dispatchCheck === 1) {
                         const endOfMonth = dateAdjust - (daysInMonth(d.getMonth() + advanceMonth))
+                       // console.log("endOfMonth", endOfMonth)
                         return endOfMonth
                     } else if (dateAdjust <= 0) { 
                         const negDay = ( dateAdjust + (daysInMonth(d.getMonth() + advanceMonth - 1)))
+                        //console.log("neg day", negDay)
                         return negDay;
                     } else if (dateAdjust > daysInMonth(d.getMonth() + advanceMonth - 1) && dispatchCheck === 0) {
                         const startOfMonth = dateAdjust - daysInMonth(d.getMonth() + advanceMonth - 1)
+                      //  console.log("start of Month", startOfMonth)
                         if (startOfMonth === 0) {
                             startOfMonth++
                         }
@@ -74,30 +84,21 @@ const InstCalandarView = () => {
     
                     }
                 return dateAdjust;
-            } else if(dispatchCheck < 0){
-                const dateAdjust = ((weekDaysArr.indexOf(day) - dayNum) + baseDay)
-                //console.log("dateAdjust", dateAdjust)
-                if (dateAdjust <= 0) {
-                    console.log("startof month",monthArr[d.getMonth() + advanceMonth] )
-
-                    const startOfMonth = dateAdjust + daysInMonth(d.getMonth() + advanceMonth)
-                  
-                    return startOfMonth
-                }
-            return dateAdjust;
+            }
         }
-        }
-       console.log("dayofWeek", dayOfWeek())
+       
         useEffect(() => {
-                if(dispatchCheck > 0 && dayOfWeek() === 2){
+            //console.log("In use Effect", dayOfWeek())
+            if(dayOfWeek() === 2) {
+                if(dispatchCheck > 0){
                     dispatch(advanceMonthAdvance(1));
                     dispatch(advanceYear(1));
                     dispatchCheck=0;
-                } else if (dispatchCheck < 0 && dayOfWeek() === 28) {
-                    console.log("reverse Month useeffect")
+                } else if (dispatchCheck < 0) {
                     dispatch(reverseMonthAdvance(1));
-                   // dispatchCheck = 0;
-                };
+                
+                }
+            };
         }, [baseDay]);
 
         return (

--- a/redux/calandarDataSlice.js
+++ b/redux/calandarDataSlice.js
@@ -2,21 +2,25 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const monthArr = ["January", "Feburary", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 const dayArr = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+let d = new Date();
 
-// {dayArr[today.getDay()]} {monthArr[today.getMonth()]} {today.getDate()}
 
 export const calandarDataSlice = createSlice({
     name: 'calandarData',
     initialState: {
-        today: 0,
+        date: d.getDate(),
+        day: d.getDay(),
+        month: d.getMonth(),
+        year: d.getFullYear(),
     },
     reducers: {
-        todayDate: (state) => {
-            state.today = 1
+        nextWeek: (state) => {
+            state.day + 7
         },
+        
     },
 });
 
-export const { todayDate } = calandarDataSlice.actions;
+export const { nextWeek } = calandarDataSlice.actions;
 
 export default calandarDataSlice.reducer;

--- a/redux/calandarDataSlice.js
+++ b/redux/calandarDataSlice.js
@@ -15,12 +15,15 @@ export const calandarDataSlice = createSlice({
     },
     reducers: {
         nextWeek: (state) => {
-            state.day + 7
+            state.day += 7
+        },
+        startingDate: (state) => {
+            new Date(state.year, state.month, 1)
         },
         
     },
 });
 
-export const { nextWeek } = calandarDataSlice.actions;
+export const { nextWeek, startingDate } = calandarDataSlice.actions;
 
 export default calandarDataSlice.reducer;

--- a/redux/calandarDataSlice.js
+++ b/redux/calandarDataSlice.js
@@ -1,7 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const monthArr = ["January", "Feburary", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-const dayArr = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
 let d = new Date();
 
 
@@ -17,8 +18,8 @@ export const calandarDataSlice = createSlice({
         nextWeek: (state) => {
             state.day += 7
         },
-        startingDate: (state) => {
-            new Date(state.year, state.month, 1)
+        startingDate: (state, action) => {
+            state.day = action.payload
         },
         
     },
@@ -27,3 +28,17 @@ export const calandarDataSlice = createSlice({
 export const { nextWeek, startingDate } = calandarDataSlice.actions;
 
 export default calandarDataSlice.reducer;
+
+//Actions
+ 
+
+export const dayOfWeek = () => {
+        for (let i=0; i < 7; i++) {
+            if (weekDaysArr.indexOf(day) === dayNum) {
+            return d.getDate()
+            } else {
+                return ((weekDaysArr.indexOf(day) - dayNum) + d.getDate())
+            }
+
+        } 
+    }

--- a/redux/calandarDataSlice.js
+++ b/redux/calandarDataSlice.js
@@ -1,0 +1,22 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const monthArr = ["January", "Feburary", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const dayArr = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+// {dayArr[today.getDay()]} {monthArr[today.getMonth()]} {today.getDate()}
+
+export const calandarDataSlice = createSlice({
+    name: 'calandarData',
+    initialState: {
+        today: 0,
+    },
+    reducers: {
+        todayDate: (state) => {
+            state.today = 1
+        },
+    },
+});
+
+export const { todayDate } = calandarDataSlice.actions;
+
+export default calandarDataSlice.reducer;

--- a/redux/reducers/rootReducer.js
+++ b/redux/reducers/rootReducer.js
@@ -1,0 +1,12 @@
+import { combineReducers } from 'redux';
+import newMessageData from '../messageDataSlice';
+import lessonData from '../lessonDataSlice';
+import calandarData from '../calandarDataSlice'
+
+const rootReducer = combineReducers({
+    newMessageData,
+    lessonData,
+    calandarData,
+})
+
+export default rootReducer;

--- a/redux/reducers/rootReducer.js
+++ b/redux/reducers/rootReducer.js
@@ -1,12 +1,14 @@
 import { combineReducers } from 'redux';
-import newMessageData from '../messageDataSlice';
-import lessonData from '../lessonDataSlice';
-import calandarData from '../calandarDataSlice'
+import messageDataSlice from '../messageDataSlice';
+import lessonDataSlice from '../lessonDataSlice';
+import calandarDataSlice from '../calandarDataSlice';
+import weekNavSlice from '../weekNavSlice'
 
 const rootReducer = combineReducers({
-    newMessageData,
-    lessonData,
-    calandarData,
+    messageData: messageDataSlice,
+    lessonData: lessonDataSlice,
+    calandarData: calandarDataSlice,
+    weekNav: weekNavSlice,
 })
 
 export default rootReducer;

--- a/redux/store.js
+++ b/redux/store.js
@@ -1,11 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import newMessageDataReducer from './messageDataSlice';
 import lessonDataReducer from './lessonDataSlice';
-
+import calandarDataReducer from './calandarDataSlice'
 
 export const store = configureStore({
   reducer: {
     messageData: newMessageDataReducer,
-    lessonData: lessonDataReducer
+    lessonData: lessonDataReducer,
+    calandarData: calandarDataReducer,
   },
 });

--- a/redux/store.js
+++ b/redux/store.js
@@ -1,12 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
-import newMessageDataReducer from './messageDataSlice';
-import lessonDataReducer from './lessonDataSlice';
-import calandarDataReducer from './calandarDataSlice'
+import rootReducer from './reducers/rootReducer'
 
 export const store = configureStore({
-  reducer: {
-    messageData: newMessageDataReducer,
-    lessonData: lessonDataReducer,
-    calandarData: calandarDataReducer,
-  },
+  reducer: rootReducer,
 });

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -1,8 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-
-const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-const monthArr =['Jan', 'Feb', 'March', 'April', 'May', 'June', 'July', 'August', 'Sept', 'Oct', 'Nov', 'Dec']
 let d = new Date();
 const getDaysInMonth = (year, month, m) => {
     return new Date(year, month, 0).getDate();
@@ -17,7 +14,7 @@ const weekNavSlice = createSlice({
     name: 'weekNav',
     initialState: {
         baseDay: d.getDate(),
-        advanceMonth: 0,
+
         month: d.getMonth(),
         year: d.getFullYear(),
 
@@ -30,7 +27,7 @@ const weekNavSlice = createSlice({
         lastWeek(state, action){
            
          },
-        advanceMonthAdvance(state, action){
+        advanceMonth(state, action){
             if((state.month) >= 11) {
                  state.month -= 12;
             }
@@ -50,5 +47,5 @@ const weekNavSlice = createSlice({
 
 
 const { actions, reducer } = weekNavSlice
-export const { nextWeek, lastWeek, advanceMonthAdvance, advanceYear } = actions
+export const { nextWeek, lastWeek, advanceMonth, advanceYear } = actions
 export default reducer

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -18,7 +18,8 @@ const weekNavSlice = createSlice({
     initialState: {
         baseDay: d.getDate(),
         advanceMonth: 0,
-        month: monthArr[d.getMonth()]
+        month: monthArr[d.getMonth()],
+        year: d.getFullYear(),
 
     },
     reducers: {
@@ -29,9 +30,11 @@ const weekNavSlice = createSlice({
             // console.log("Month", monthArr[d.getMonth() + state.advanceMonth], d.getMonth() + state.advanceMonth)
             // console.log("days in Month", daysInMonth(d.getMonth() + state.advanceMonth))
             // console.log("next week number", state.baseDay + action.payload)
-            if (state.baseDay + action.payload > daysInMonth(d.getMonth() + state.advanceMonth)) {
-                state.baseDay = state.baseDay + action.payload - daysInMonth(d.getMonth() + state.advanceMonth);
+            if (state.baseDay + action.payload > daysInMonth(d.getMonth() + state.advanceMonth )) {
+                state.baseDay = state.baseDay + action.payload - daysInMonth(d.getMonth() + state.advanceMonth );
                 // console.log("in IF state baseDay", state.baseDay)
+                // console.log("in IF state plus payload", state.baseDay + action.payload)
+                // console.log("in if d.getMonth plust state advance month", d.getMonth() + state.advanceMonth)
              } else {
                 state.baseDay +=action.payload;
                 // console.log("in ELSE state baseDay", state.baseDay)
@@ -49,13 +52,17 @@ const weekNavSlice = createSlice({
              state.month = monthArr[d.getMonth() + state.advanceMonth]
              console.log("get plus ad", d.getMonth() + state.advanceMonth)
              console.log("Advance Month", state.advanceMonth)
-        } 
+        } ,
+        advanceYear(state, action){
+            if(state.month === "Jan")
+            state.year += action.payload
+        }
     },
 });
 
 
 const { actions, reducer } = weekNavSlice
-export const { nextWeek, lastWeek, advanceMonthAdvance } = actions
+export const { nextWeek, lastWeek, advanceMonthAdvance, advanceYear } = actions
 export default reducer
 
 //Actions

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -17,24 +17,24 @@ const weekNavSlice = createSlice({
     name: 'weekNav',
     initialState: {
         baseDay: d.getDate(),
-        advanceMonth: 1,
+        advanceMonth: 0,
         month: monthArr[d.getMonth()]
 
     },
     reducers: {
         nextWeek(state, action){
-            console.log("state baseDay", state.baseDay)
-            console.log("state advance", state.advanceMonth)
+            // console.log("state baseDay", state.baseDay)
+            // console.log("state advance", state.advanceMonth)
 
-            console.log("Month", monthArr[d.getMonth() + state.advanceMonth], d.getMonth() + state.advanceMonth)
-            console.log("days in Month", daysInMonth(d.getMonth() + state.advanceMonth))
-            console.log("next week number", state.baseDay + action.payload)
+            // console.log("Month", monthArr[d.getMonth() + state.advanceMonth], d.getMonth() + state.advanceMonth)
+            // console.log("days in Month", daysInMonth(d.getMonth() + state.advanceMonth))
+            // console.log("next week number", state.baseDay + action.payload)
             if (state.baseDay + action.payload > daysInMonth(d.getMonth() + state.advanceMonth)) {
                 state.baseDay = state.baseDay + action.payload - daysInMonth(d.getMonth() + state.advanceMonth);
-                console.log("in IF state baseDay", state.baseDay)
+                // console.log("in IF state baseDay", state.baseDay)
              } else {
                 state.baseDay +=action.payload;
-                console.log("in ELSE state baseDay", state.baseDay)
+                // console.log("in ELSE state baseDay", state.baseDay)
              }
            
         },
@@ -42,8 +42,12 @@ const weekNavSlice = createSlice({
            state.baseDay -= action.payload
          },
          advanceMonthAdvance(state, action){
+            if((d.getMonth() + state.advanceMonth) >= 11) {
+                state.advanceMonth -= 12;
+            }
              state.advanceMonth += action.payload
              state.month = monthArr[d.getMonth() + state.advanceMonth]
+             console.log("get plus ad", d.getMonth() + state.advanceMonth)
              console.log("Advance Month", state.advanceMonth)
         } 
     },

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -17,7 +17,6 @@ const weekNavSlice = createSlice({
     name: 'weekNav',
     initialState: {
         baseDay: d.getDate(),
-        advanceMonth: 0,
         month: d.getMonth(),
         year: d.getFullYear(),
 
@@ -26,17 +25,10 @@ const weekNavSlice = createSlice({
         nextWeek(state, action){
             console.log("Next Week bD", state.baseDay)
             state.baseDay +=action.payload;
-            // if(state.baseDay > daysInMonth(d.getMonth() + (state.month-1))) {
-            //     console.log("Next Week if baseday > days in THIS month ")
-                
-            //     state.baseDay = state.baseDay - daysInMonth(d.getMonth() + (state.month-1))
-            // }
         },
         lastWeek(state, action){
-            // state.baseDay -=action.payload;
-            // if(state.baseDay < 0) {
-            //     state.baseDay = state.baseDay + daysInMonth(d.getMonth() + state.advanceMonth)
-            // }
+            state.baseDay -=action.payload;
+            console.log("LAst Week")
          },
         advanceMonthAdvance(state, action){
             if((state.month) >= 11) {
@@ -44,28 +36,31 @@ const weekNavSlice = createSlice({
             }
              state.month += action.payload
              state.baseDay -= daysInMonth(state.month-1)
-             //state.month = monthArr[d.getMonth() + state.advanceMonth]
-
              console.log("Month in Slice", state.month)
     
         } ,
-        // reverseMonthAdvance(state, action){
-        //     if((d.getMonth() + state.advanceMonth) <= 0) {
-        //         state.advanceMonth += 12;
-        //     }
-        //      state.advanceMonth -= action.payload
-        //      state.month = monthArr[d.getMonth() + state.advanceMonth]
-        //} ,
+        reverseMonthAdvance(state, action){
+            if((state.month) <= 0) {
+                state.month += 11;
+           }
+            state.month -= action.payload
+            state.baseDay += daysInMonth(state.month)
+            console.log("Month in Slice", state.month)
+        } ,
         advanceYear(state, action){
             if(state.month === 0)
             state.year += action.payload
+        },
+        reverseYear(state, action){
+            if(state.month === 11)
+            state.year -= action.payload
         }
     },
 });
 
 
 const { actions, reducer } = weekNavSlice
-export const { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear } = actions
+export const { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear, reverseYear } = actions
 export default reducer
 
 //Actions

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -24,11 +24,19 @@ const weekNavSlice = createSlice({
     },
     reducers: {
         nextWeek(state, action){
-            if (state.baseDay + action.payload > daysInMonth(d.getMonth() + state.advanceMonth )) {
-                state.baseDay = state.baseDay + action.payload - daysInMonth(d.getMonth() + state.advanceMonth );
-             } else {
-                state.baseDay +=action.payload;
-             }
+            // console.log("base day plus 7", state.baseDay + action.payload)
+            // console.log("advance month", state.advanceMonth)
+            // console.log("days in this month", daysInMonth(d.getMonth() + state.advanceMonth ))
+            state.baseDay +=action.payload;
+
+            if(state.baseDay >= daysInMonth(d.getMonth() + state.advanceMonth)) {
+                // console.log("days in month", daysInMonth(d.getMonth() + state.advanceMonth ))
+                // console.log("baseday", state.baseDay)
+                // console.log("today", d.getDate())
+                state.baseDay = state.baseDay - daysInMonth(d.getMonth() + state.advanceMonth)
+            }
+                
+             
            
         },
         lastWeek(state, action){
@@ -44,6 +52,9 @@ const weekNavSlice = createSlice({
             }
              state.advanceMonth += action.payload
              state.month = monthArr[d.getMonth() + state.advanceMonth]
+            //  if(state.baseDay >(d.getMonth() + (state.advanceMonth  ))) {
+            //  state.baseDay = state.baseDay - (d.getMonth() + (state.advanceMonth -1 ))
+            // }
         } ,
         reverseMonthAdvance(state, action){
             if((d.getMonth() + state.advanceMonth) >= 11) {

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -24,39 +24,35 @@ const weekNavSlice = createSlice({
     },
     reducers: {
         nextWeek(state, action){
-            // console.log("base day plus 7", state.baseDay + action.payload)
-            // console.log("advance month", state.advanceMonth)
-            // console.log("days in this month", daysInMonth(d.getMonth() + state.advanceMonth ))
             state.baseDay +=action.payload;
-
+            console.log("next Week")
             if(state.baseDay >= daysInMonth(d.getMonth() + state.advanceMonth)) {
-                // console.log("days in month", daysInMonth(d.getMonth() + state.advanceMonth ))
-                // console.log("baseday", state.baseDay)
-                // console.log("today", d.getDate())
                 state.baseDay = state.baseDay - daysInMonth(d.getMonth() + state.advanceMonth)
             }
-                
-             
-           
         },
         lastWeek(state, action){
-            if (state.baseDay - action.payload < 1 ) {
-                state.baseDay = state.baseDay - action.payload + daysInMonth(d.getMonth() + state.advanceMonth );
-             } else {
-                state.baseDay -=action.payload;
-             }
+            state.baseDay -=action.payload;
+            console.log("last Week")
+            console.log("base day", state.baseDay)
+            console.log("state.advanceMonth", state.advanceMonth)
+            if(state.baseDay < 0) {
+                console.log("last week In IF")
+                state.baseDay = state.baseDay + daysInMonth(d.getMonth() + state.advanceMonth)
+                console.log("state.baseDay", state.baseDay)
+                console.log("days in month", daysInMonth(d.getMonth() + state.advanceMonth))
+                console.log("Month", monthArr[d.getMonth() + state.advanceMonth])
+            }
          },
-         advanceMonthAdvance(state, action){
+        advanceMonthAdvance(state, action){
             if((d.getMonth() + state.advanceMonth) >= 11) {
                  state.advanceMonth -= 12;
             }
-            console.log((d.getMonth() + state.advanceMonth))
              state.advanceMonth += action.payload
              state.month = monthArr[d.getMonth() + state.advanceMonth]
         } ,
         reverseMonthAdvance(state, action){
-            if((d.getMonth() + state.advanceMonth) >= 11) {
-                state.advanceMonth -= 12;
+            if((d.getMonth() + state.advanceMonth) <= 0) {
+                state.advanceMonth += 12;
             }
              state.advanceMonth -= action.payload
              state.month = monthArr[d.getMonth() + state.advanceMonth]

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -18,17 +18,17 @@ const weekNavSlice = createSlice({
     initialState: {
         baseDay: d.getDate(),
         advanceMonth: 0,
-        month: monthArr[d.getMonth()],
+        month: d.getMonth(),
         year: d.getFullYear(),
 
     },
     reducers: {
         nextWeek(state, action){
             state.baseDay +=action.payload;
-            if(state.baseDay > daysInMonth(d.getMonth() + (state.advanceMonth - 1))) {
-                console.log("Next Week if baseday > days in last month ")
+            if(state.baseDay > daysInMonth(d.getMonth() + (state.month-1))) {
+                console.log("Next Week if baseday > days in THIS month ")
                 
-                state.baseDay = state.baseDay - daysInMonth(d.getMonth() + (state.advanceMonth - 1))
+                state.baseDay = state.baseDay - daysInMonth(d.getMonth() + (state.month-1))
             }
             console.log("Next Week bD", state.baseDay)
         },
@@ -39,14 +39,14 @@ const weekNavSlice = createSlice({
             // }
          },
         advanceMonthAdvance(state, action){
-            if((d.getMonth() + state.advanceMonth) >= 11) {
-                 state.advanceMonth -= 12;
+            if((state.month) > 11) {
+                 state.month -= 11;
             }
-             state.advanceMonth += action.payload
-             state.month = monthArr[d.getMonth() + state.advanceMonth]
-             console.log("advanceMonth in SLICE",state.advanceMonth)
+             state.month += action.payload
+             //state.month = monthArr[d.getMonth() + state.advanceMonth]
+
              console.log("Month in Slice", state.month)
-             console.log("Month NUMBER in Slice", d.getMonth()+ state.advanceMonth)
+    
         } ,
         // reverseMonthAdvance(state, action){
         //     if((d.getMonth() + state.advanceMonth) <= 0) {
@@ -56,7 +56,7 @@ const weekNavSlice = createSlice({
         //      state.month = monthArr[d.getMonth() + state.advanceMonth]
         //} ,
         advanceYear(state, action){
-            if(state.month === "Jan")
+            if(state.month === 0)
             state.year += action.payload
         }
     },

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -48,13 +48,11 @@ const weekNavSlice = createSlice({
          },
          advanceMonthAdvance(state, action){
             if((d.getMonth() + state.advanceMonth) >= 11) {
-                state.advanceMonth -= 12;
+                 state.advanceMonth -= 12;
             }
+            console.log((d.getMonth() + state.advanceMonth))
              state.advanceMonth += action.payload
              state.month = monthArr[d.getMonth() + state.advanceMonth]
-            //  if(state.baseDay >(d.getMonth() + (state.advanceMonth  ))) {
-            //  state.baseDay = state.baseDay - (d.getMonth() + (state.advanceMonth -1 ))
-            // }
         } ,
         reverseMonthAdvance(state, action){
             if((d.getMonth() + state.advanceMonth) >= 11) {

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -24,25 +24,19 @@ const weekNavSlice = createSlice({
     },
     reducers: {
         nextWeek(state, action){
-            // console.log("state baseDay", state.baseDay)
-            // console.log("state advance", state.advanceMonth)
-
-            // console.log("Month", monthArr[d.getMonth() + state.advanceMonth], d.getMonth() + state.advanceMonth)
-            // console.log("days in Month", daysInMonth(d.getMonth() + state.advanceMonth))
-            // console.log("next week number", state.baseDay + action.payload)
             if (state.baseDay + action.payload > daysInMonth(d.getMonth() + state.advanceMonth )) {
                 state.baseDay = state.baseDay + action.payload - daysInMonth(d.getMonth() + state.advanceMonth );
-                // console.log("in IF state baseDay", state.baseDay)
-                // console.log("in IF state plus payload", state.baseDay + action.payload)
-                // console.log("in if d.getMonth plust state advance month", d.getMonth() + state.advanceMonth)
              } else {
                 state.baseDay +=action.payload;
-                // console.log("in ELSE state baseDay", state.baseDay)
              }
            
         },
         lastWeek(state, action){
-           state.baseDay -= action.payload
+            if (state.baseDay - action.payload < 1 ) {
+                state.baseDay = state.baseDay - action.payload + daysInMonth(d.getMonth() + state.advanceMonth );
+             } else {
+                state.baseDay -=action.payload;
+             }
          },
          advanceMonthAdvance(state, action){
             if((d.getMonth() + state.advanceMonth) >= 11) {
@@ -50,8 +44,13 @@ const weekNavSlice = createSlice({
             }
              state.advanceMonth += action.payload
              state.month = monthArr[d.getMonth() + state.advanceMonth]
-             console.log("get plus ad", d.getMonth() + state.advanceMonth)
-             console.log("Advance Month", state.advanceMonth)
+        } ,
+        reverseMonthAdvance(state, action){
+            if((d.getMonth() + state.advanceMonth) >= 11) {
+                state.advanceMonth -= 12;
+            }
+             state.advanceMonth -= action.payload
+             state.month = monthArr[d.getMonth() + state.advanceMonth]
         } ,
         advanceYear(state, action){
             if(state.month === "Jan")
@@ -62,7 +61,7 @@ const weekNavSlice = createSlice({
 
 
 const { actions, reducer } = weekNavSlice
-export const { nextWeek, lastWeek, advanceMonthAdvance, advanceYear } = actions
+export const { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear } = actions
 export default reducer
 
 //Actions

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -24,35 +24,39 @@ const weekNavSlice = createSlice({
     },
     reducers: {
         nextWeek(state, action){
+            // console.log("base day plus 7", state.baseDay + action.payload)
+            // console.log("advance month", state.advanceMonth)
+            // console.log("days in this month", daysInMonth(d.getMonth() + state.advanceMonth ))
             state.baseDay +=action.payload;
-            console.log("next Week")
+
             if(state.baseDay >= daysInMonth(d.getMonth() + state.advanceMonth)) {
+                // console.log("days in month", daysInMonth(d.getMonth() + state.advanceMonth ))
+                // console.log("baseday", state.baseDay)
+                // console.log("today", d.getDate())
                 state.baseDay = state.baseDay - daysInMonth(d.getMonth() + state.advanceMonth)
             }
+                
+             
+           
         },
         lastWeek(state, action){
-            state.baseDay -=action.payload;
-            console.log("last Week")
-            console.log("base day", state.baseDay)
-            console.log("state.advanceMonth", state.advanceMonth)
-            if(state.baseDay < 0) {
-                console.log("last week In IF")
-                state.baseDay = state.baseDay + daysInMonth(d.getMonth() + state.advanceMonth)
-                console.log("state.baseDay", state.baseDay)
-                console.log("days in month", daysInMonth(d.getMonth() + state.advanceMonth))
-                console.log("Month", monthArr[d.getMonth() + state.advanceMonth])
-            }
+            if (state.baseDay - action.payload < 1 ) {
+                state.baseDay = state.baseDay - action.payload + daysInMonth(d.getMonth() + state.advanceMonth );
+             } else {
+                state.baseDay -=action.payload;
+             }
          },
-        advanceMonthAdvance(state, action){
+         advanceMonthAdvance(state, action){
             if((d.getMonth() + state.advanceMonth) >= 11) {
                  state.advanceMonth -= 12;
             }
+            console.log((d.getMonth() + state.advanceMonth))
              state.advanceMonth += action.payload
              state.month = monthArr[d.getMonth() + state.advanceMonth]
         } ,
         reverseMonthAdvance(state, action){
-            if((d.getMonth() + state.advanceMonth) <= 0) {
-                state.advanceMonth += 12;
+            if((d.getMonth() + state.advanceMonth) >= 11) {
+                state.advanceMonth -= 12;
             }
              state.advanceMonth -= action.payload
              state.month = monthArr[d.getMonth() + state.advanceMonth]

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -24,13 +24,13 @@ const weekNavSlice = createSlice({
     },
     reducers: {
         nextWeek(state, action){
-            state.baseDay +=action.payload;
-            if(state.baseDay > daysInMonth(d.getMonth() + (state.month-1))) {
-                console.log("Next Week if baseday > days in THIS month ")
-                
-                state.baseDay = state.baseDay - daysInMonth(d.getMonth() + (state.month-1))
-            }
             console.log("Next Week bD", state.baseDay)
+            state.baseDay +=action.payload;
+            // if(state.baseDay > daysInMonth(d.getMonth() + (state.month-1))) {
+            //     console.log("Next Week if baseday > days in THIS month ")
+                
+            //     state.baseDay = state.baseDay - daysInMonth(d.getMonth() + (state.month-1))
+            // }
         },
         lastWeek(state, action){
             // state.baseDay -=action.payload;
@@ -39,10 +39,11 @@ const weekNavSlice = createSlice({
             // }
          },
         advanceMonthAdvance(state, action){
-            if((state.month) > 11) {
-                 state.month -= 11;
+            if((state.month) >= 11) {
+                 state.month -= 12;
             }
              state.month += action.payload
+             state.baseDay -= daysInMonth(state.month-1)
              //state.month = monthArr[d.getMonth() + state.advanceMonth]
 
              console.log("Month in Slice", state.month)

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -25,23 +25,18 @@ const weekNavSlice = createSlice({
     reducers: {
         nextWeek(state, action){
             state.baseDay +=action.payload;
-            console.log("next Week")
-            if(state.baseDay >= daysInMonth(d.getMonth() + state.advanceMonth)) {
-                state.baseDay = state.baseDay - daysInMonth(d.getMonth() + state.advanceMonth)
+            if(state.baseDay > daysInMonth(d.getMonth() + (state.advanceMonth - 1))) {
+                console.log("Next Week if baseday > days in last month ")
+                
+                state.baseDay = state.baseDay - daysInMonth(d.getMonth() + (state.advanceMonth - 1))
             }
+            console.log("Next Week bD", state.baseDay)
         },
         lastWeek(state, action){
-            state.baseDay -=action.payload;
-            console.log("last Week")
-            console.log("base day", state.baseDay)
-            console.log("state.advanceMonth", state.advanceMonth)
-            if(state.baseDay < 0) {
-                console.log("last week In IF")
-                state.baseDay = state.baseDay + daysInMonth(d.getMonth() + state.advanceMonth)
-                console.log("state.baseDay", state.baseDay)
-                console.log("days in month", daysInMonth(d.getMonth() + state.advanceMonth))
-                console.log("Month", monthArr[d.getMonth() + state.advanceMonth])
-            }
+            // state.baseDay -=action.payload;
+            // if(state.baseDay < 0) {
+            //     state.baseDay = state.baseDay + daysInMonth(d.getMonth() + state.advanceMonth)
+            // }
          },
         advanceMonthAdvance(state, action){
             if((d.getMonth() + state.advanceMonth) >= 11) {
@@ -49,14 +44,17 @@ const weekNavSlice = createSlice({
             }
              state.advanceMonth += action.payload
              state.month = monthArr[d.getMonth() + state.advanceMonth]
+             console.log("advanceMonth in SLICE",state.advanceMonth)
+             console.log("Month in Slice", state.month)
+             console.log("Month NUMBER in Slice", d.getMonth()+ state.advanceMonth)
         } ,
-        reverseMonthAdvance(state, action){
-            if((d.getMonth() + state.advanceMonth) <= 0) {
-                state.advanceMonth += 12;
-            }
-             state.advanceMonth -= action.payload
-             state.month = monthArr[d.getMonth() + state.advanceMonth]
-        } ,
+        // reverseMonthAdvance(state, action){
+        //     if((d.getMonth() + state.advanceMonth) <= 0) {
+        //         state.advanceMonth += 12;
+        //     }
+        //      state.advanceMonth -= action.payload
+        //      state.month = monthArr[d.getMonth() + state.advanceMonth]
+        //} ,
         advanceYear(state, action){
             if(state.month === "Jan")
             state.year += action.payload

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { applyMiddleware } from 'redux';
+
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-
+const monthArr =['Jan', 'Feb', 'March', 'April', 'May', 'June', 'July', 'August', 'Sept', 'Oct', 'Nov', 'Dec']
 let d = new Date();
 const getDaysInMonth = (year, month, m) => {
     return new Date(year, month, 0).getDate();
@@ -16,31 +16,42 @@ const daysInMonth = (m) => {
 const weekNavSlice = createSlice({
     name: 'weekNav',
     initialState: {
-        today: d.getDate(),
-        nextMonth: 1,
+        baseDay: d.getDate(),
+        advanceMonth: 1,
+        month: monthArr[d.getMonth()]
 
     },
     reducers: {
         nextWeek(state, action){
-            if (state.today + action.payload > daysInMonth(d.getMonth() + state.nextMonth)) {
-                state.today = state.today + action.payload - daysInMonth(d.getMonth() + state.nextMonth);
+            console.log("state baseDay", state.baseDay)
+            console.log("state advance", state.advanceMonth)
+
+            console.log("Month", monthArr[d.getMonth() + state.advanceMonth], d.getMonth() + state.advanceMonth)
+            console.log("days in Month", daysInMonth(d.getMonth() + state.advanceMonth))
+            console.log("next week number", state.baseDay + action.payload)
+            if (state.baseDay + action.payload > daysInMonth(d.getMonth() + state.advanceMonth)) {
+                state.baseDay = state.baseDay + action.payload - daysInMonth(d.getMonth() + state.advanceMonth);
+                console.log("in IF state baseDay", state.baseDay)
              } else {
-                state.today +=action.payload;
+                state.baseDay +=action.payload;
+                console.log("in ELSE state baseDay", state.baseDay)
              }
            
         },
         lastWeek(state, action){
-           state.today -= action.payload
+           state.baseDay -= action.payload
          },
-         nextMonthAdvance(state){
-            state.nextMonth++
+         advanceMonthAdvance(state, action){
+             state.advanceMonth += action.payload
+             state.month = monthArr[d.getMonth + state.advanceMonth]
+             console.log("Advance Month", state.advanceMonth)
         } 
     },
 });
 
 
 const { actions, reducer } = weekNavSlice
-export const { nextWeek, lastWeek, nextMonthAdvance } = actions
+export const { nextWeek, lastWeek, advanceMonthAdvance } = actions
 export default reducer
 
 //Actions

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -1,27 +1,46 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { applyMiddleware } from 'redux';
 
 const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 let d = new Date();
-const dayNum = d.getDay();
+const getDaysInMonth = (year, month, m) => {
+    return new Date(year, month, 0).getDate();
 
-console.log(dayNum)
-
+}
+const currentYear = d.getFullYear()
+const daysInMonth = (m) => {
+    return getDaysInMonth(currentYear, m + 1, 0)
+}
 
 const weekNavSlice = createSlice({
     name: 'weekNav',
     initialState: {
-        today: dayNum,
+        today: d.getDate(),
+        nextMonth: 1,
+
     },
     reducers: {
-        nextWeek: (state) => {
-           state.today += 7
-        }, 
+        nextWeek(state, action){
+            if (state.today + action.payload > daysInMonth(d.getMonth() + state.nextMonth)) {
+                state.today = state.today + action.payload - daysInMonth(d.getMonth() + state.nextMonth);
+             } else {
+                state.today +=action.payload;
+             }
+           
+        },
+        lastWeek(state, action){
+           state.today -= action.payload
+         },
+         nextMonthAdvance(state){
+            state.nextMonth += 1
+        } 
     },
 });
 
+
 const { actions, reducer } = weekNavSlice
-export const { nextWeek } = actions
+export const { nextWeek, lastWeek, nextMonthAdvance } = actions
 export default reducer
 
 //Actions

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -33,7 +33,7 @@ const weekNavSlice = createSlice({
            state.today -= action.payload
          },
          nextMonthAdvance(state){
-            state.nextMonth += 1
+            state.nextMonth++
         } 
     },
 });

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -43,7 +43,7 @@ const weekNavSlice = createSlice({
          },
          advanceMonthAdvance(state, action){
              state.advanceMonth += action.payload
-             state.month = monthArr[d.getMonth + state.advanceMonth]
+             state.month = monthArr[d.getMonth() + state.advanceMonth]
              console.log("Advance Month", state.advanceMonth)
         } 
     },

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -1,0 +1,29 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const weekDaysArr = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+let d = new Date();
+const dayNum = d.getDay();
+
+console.log(dayNum)
+
+
+const weekNavSlice = createSlice({
+    name: 'weekNav',
+    initialState: {
+        today: dayNum,
+    },
+    reducers: {
+        nextWeek: (state) => {
+           state.today += 7
+        }, 
+    },
+});
+
+const { actions, reducer } = weekNavSlice
+export const { nextWeek } = actions
+export default reducer
+
+//Actions
+ 
+

--- a/redux/weekNavSlice.js
+++ b/redux/weekNavSlice.js
@@ -17,6 +17,7 @@ const weekNavSlice = createSlice({
     name: 'weekNav',
     initialState: {
         baseDay: d.getDate(),
+        advanceMonth: 0,
         month: d.getMonth(),
         year: d.getFullYear(),
 
@@ -27,8 +28,7 @@ const weekNavSlice = createSlice({
             state.baseDay +=action.payload;
         },
         lastWeek(state, action){
-            state.baseDay -=action.payload;
-            console.log("LAst Week")
+           
          },
         advanceMonthAdvance(state, action){
             if((state.month) >= 11) {
@@ -36,16 +36,6 @@ const weekNavSlice = createSlice({
             }
              state.month += action.payload
              state.baseDay -= daysInMonth(state.month-1)
-             console.log("Month in Slice", state.month)
-    
-        } ,
-        reverseMonthAdvance(state, action){
-            if((state.month) <= 0) {
-                state.month += 11;
-           }
-            state.month -= action.payload
-            state.baseDay += daysInMonth(state.month)
-            console.log("Month in Slice", state.month)
         } ,
         advanceYear(state, action){
             if(state.month === 0)
@@ -60,9 +50,5 @@ const weekNavSlice = createSlice({
 
 
 const { actions, reducer } = weekNavSlice
-export const { nextWeek, lastWeek, advanceMonthAdvance, reverseMonthAdvance, advanceYear, reverseYear } = actions
+export const { nextWeek, lastWeek, advanceMonthAdvance, advanceYear } = actions
 export default reducer
-
-//Actions
- 
-

--- a/resources.md
+++ b/resources.md
@@ -14,4 +14,11 @@ https://medium.com/how-to-react/how-to-setup-redux-in-nextjs-5bce0d82b8de
 https://vpilip.com/how-setup-nextjs-with-redux-and-redux-debuger/
 https://github.com/VladymyrPylypchatin/nextjs-redux-boilerplate/blob/master/src/pages/_app.js
 **Redux Setup FCC**
-https://www.freecodecamp.org/news/redux-for-beginners-the-brain-friendly-guide-to-redux/
+https://www.freecodecamp.org/news/redux-for-beginners-the-brain-friendly-guide-to-redux/4
+**Redux Stuff**
+https://www.saltycrane.com/blog/2018/04/what-does-redux-combinereducers-do/#:~:text=Redux%20uses%20a%20single%20root,and%20returns%20a%20new%20state.
+https://redux-toolkit.js.org/tutorials/quick-start
+**Calandar Resources**
+https://programmingwithmosh.com/react/build-a-react-calendar-component-from-scratch/
+https://www.w3schools.com/js/js_date_methods.asp
+https://medium.com/@nitinpatel_20236/challenge-of-building-a-calendar-with-pure-javascript-a86f1303267d

--- a/resources.md
+++ b/resources.md
@@ -22,3 +22,4 @@ https://redux-toolkit.js.org/tutorials/quick-start
 https://programmingwithmosh.com/react/build-a-react-calendar-component-from-scratch/
 https://www.w3schools.com/js/js_date_methods.asp
 https://medium.com/@nitinpatel_20236/challenge-of-building-a-calendar-with-pure-javascript-a86f1303267d
+https://justacoding.blog/react-calendar-component-example-with-events/

--- a/styles/instructorCal.module.scss
+++ b/styles/instructorCal.module.scss
@@ -17,6 +17,7 @@ $calItemInner-color: #c9328f;
     
     .weekContainer {
         display:flex;
+        flex-direction: row;
         background-color: $calComponent-color;
         width: 90%;
         height: 45%;


### PR DESCRIPTION
- Connected inst-cal-view to store & calandarDataSlice
- Attempting to isolate the starting day of each week
- Days of Week
- connected days of week number to weekNavSLice state
- week advance
- end of day
- better logic
- advanceMonthAdvance
- State save for Advance Month
- start of month exception
- calandar advances through next month
- calandar works for one year
- Calandar advance works
- working on last week function
- undo to next week working
- working on last week
- Trying to simplify and debug next month. Seems to be the advance month feature is problematic. Am removing it and adding to month state the same way I do to baseDay
- Days ahead and Days behind
- Calandar Advance Complete
- Reverse Month
- removed console logs and unnecessary notes
- removed unnecessary actions, reducers in weekNavSlice and instructor-calandar-view
