### PR TITLE
Feature Complete

### DIFF
--- a/components/lesson-controls/lesson-create-attachment.js
+++ b/components/lesson-controls/lesson-create-attachment.js
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { updateLessonAttachmentList, removeLessonAttachment } from '../../redux/slices/lessonControlSlice';
+import { updateLessonAttachmentList, removeLessonAttachment, clearLessonAttachmentList, toggleAttachClear } from '../../redux/slices/lessonControlSlice';
 //https://www.pluralsight.com/guides/uploading-files-with-reactjs
 //https://www.pluralsight.com/guides/manipulating-arrays-and-objects-in-state-with-react
 
-export default function LessonCreateAttachment ({toggleAttachClear}) {
+export default function LessonCreateAttachment () {
 
 
     const [selectedFile, setSelectedFile] = useState();
@@ -12,19 +12,21 @@ export default function LessonCreateAttachment ({toggleAttachClear}) {
     const [attachArray, setAttachArray] = useState([]);
 
 
-    useEffect(() => {
-        console.log("attachArray is updated", attachArray)
-        console.log("toggleAttachClear", toggleAttachClear)
-        if(toggleAttachClear === true) {
-            setAttachArray([])
-            !toggleAttachClear
-            return attachArray
-        }
-    }, [selectedFile, isSelected, attachArray, toggleAttachClear]);
-
-    const removeIndex = useSelector(state => state.removeIndex)
+    const removeIndex = useSelector(state => state.lessonControl.removeIndex)
+    const attachClear = useSelector(state => state.lessonControl.attachClear)
 
     const dispatch = useDispatch();
+
+    useEffect(() => {
+        console.log("attachArray is updated", attachArray)
+        console.log(" in useEffect:", attachClear)
+        if(attachClear === true) {
+            console.log("in UseEffect IF")
+            setAttachArray([])
+            dispatch(clearLessonAttachmentList([]))
+            dispatch(toggleAttachClear(false))
+        }
+    }, [attachClear]);
     
     
     const handleSearchAttachment = (e) => {

--- a/components/lesson-controls/lesson-create-control.js
+++ b/components/lesson-controls/lesson-create-control.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { nanoid } from '@reduxjs/toolkit';
 import { addLesson } from '../../redux/slices/lessonDataSlice'
 import LessonCreateAttachment from './lesson-create-attachment';
-import { clearLessonAttachmentList } from '../../redux/slices/lessonControlSlice';
+import { clearLessonAttachmentList, toggleAttachClear } from '../../redux/slices/lessonControlSlice';
 
 // const lessonDayArr = ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'];
 
@@ -22,7 +22,6 @@ export default function LessonCreateControl () {
     const [attachment, setAttachment] = useState([]);
     const [status, setStatus] = useState('Available');
     const [link, setLink] = useState('Discord');
-    let toggleAttachClear = false
 
     const dispatch = useDispatch();
 
@@ -82,7 +81,7 @@ export default function LessonCreateControl () {
         setStatus('Available')
         setLink('Discord')
         dispatch(clearLessonAttachmentList())
-        !toggleAttachClear
+        dispatch(toggleAttachClear(true))
     }
 
     if(!createLesson){
@@ -213,7 +212,6 @@ export default function LessonCreateControl () {
             </form>
                 <div className='row'>
                     <LessonCreateAttachment
-                        toggleAttachClear={toggleAttachClear} 
                         onChange={onAttachmentChange}/>
                     <form className="lessonControlBtn col">
                         <button 

--- a/redux/slices/lessonControlSlice.js
+++ b/redux/slices/lessonControlSlice.js
@@ -17,20 +17,20 @@ export const lessonControlSlice = createSlice({
         },
         updateLessonAttachmentList(state, action) {
             state.lessonAttachmentList = [...state.lessonAttachmentList, action.payload]
-            console.log("in slice lesson attachment List", state.lessonAttachmentList)
         },
         removeLessonAttachment(state, action) {
             state.removeIndex = action.payload
             state.lessonAttachmentList = action.payload
-            console.log("in slice removeIndex", state.removeIndex)
         },
         clearLessonAttachmentList(state) {
             state.lessonAttachmentList = []
-            console.log("in clear Lesson Attachment List")
         },
-        
+        toggleAttachClear(state, action) {
+            state.attachClear = action.payload
+            console.log('in toggleAttachClear', state.attachClear)
+        }
     },
 });
 
-export const { showEditLesson, showCreateLesson, updateLessonAttachmentList, removeLessonAttachment, clearLessonAttachmentList } = lessonControlSlice.actions;
+export const { showEditLesson, showCreateLesson, updateLessonAttachmentList, removeLessonAttachment, clearLessonAttachmentList, toggleAttachClear } = lessonControlSlice.actions;
 export default lessonControlSlice.reducer;


### PR DESCRIPTION
Re-added toggleAttachClear in lessonControlSlice and fed through code to clear Lesson Attachment List on Create Lesson Click. App still displays lesson attachments in lesson table.
